### PR TITLE
fix: prevent python-dotenv from searching upward in parent directories

### DIFF
--- a/src/mcp_ticketer/cli/main.py
+++ b/src/mcp_ticketer/cli/main.py
@@ -37,13 +37,16 @@ from .ticket_commands import app as ticket_app
 
 # Load environment variables from .env files
 # Priority: .env.local (highest) > .env (base)
-# This matches the pattern used in worker.py and server.py
+# We explicitly specify file paths to avoid upward directory search
+# which could load .env files from unrelated parent projects
+env_file = Path.cwd() / ".env"
+env_local = Path.cwd() / ".env.local"
 
-# Load .env first (base configuration)
-load_dotenv()
+# Load .env first (base configuration) if it exists
+if env_file.exists():
+    load_dotenv(env_file)
 
 # Load .env.local with override=True (project-specific overrides)
-env_local = Path.cwd() / ".env.local"
 if env_local.exists():
     load_dotenv(env_local, override=True)
 

--- a/src/mcp_ticketer/mcp/server/main.py
+++ b/src/mcp_ticketer/mcp/server/main.py
@@ -1098,25 +1098,22 @@ async def main() -> None:
 
     # Load environment variables AFTER working directory has been set by __main__.py
     # This ensures we load .env files from the target project directory, not from where the command is executed
+    # We explicitly avoid upward directory search to prevent loading .env files from parent projects
     env_local_file = Path.cwd() / ".env.local"
+    env_file = Path.cwd() / ".env"
+
     if env_local_file.exists():
         load_dotenv(env_local_file, override=True)
         sys.stderr.write(f"[MCP Server] Loaded environment from: {env_local_file}\n")
         logger.debug(f"Loaded environment from: {env_local_file}")
+    elif env_file.exists():
+        load_dotenv(env_file, override=True)
+        sys.stderr.write(f"[MCP Server] Loaded environment from: {env_file}\n")
+        logger.debug(f"Loaded environment from: {env_file}")
     else:
-        # Fall back to .env
-        env_file = Path.cwd() / ".env"
-        if env_file.exists():
-            load_dotenv(env_file, override=True)
-            sys.stderr.write(f"[MCP Server] Loaded environment from: {env_file}\n")
-            logger.debug(f"Loaded environment from: {env_file}")
-        else:
-            # Try default dotenv loading (searches upward)
-            load_dotenv(override=True)
-            sys.stderr.write(
-                "[MCP Server] Loaded environment from default search path\n"
-            )
-            logger.debug("Loaded environment from default search path")
+        # No .env file found in project directory - this is okay
+        sys.stderr.write("[MCP Server] No .env file found in project directory\n")
+        logger.info("No .env file found in current directory")
 
     # Initialize defaults
     adapter_type = "aitrackdown"


### PR DESCRIPTION
## Summary

Fixes the python-dotenv warning about parsing issues by preventing upward directory searches.

### Problem
When mcp-ticketer runs in a directory without an `.env` file, the fallback `load_dotenv()` call would search upward through parent directories and potentially load `.env` files from unrelated projects. This resulted in parsing warnings:

```
2025-12-16 14:01:08,003 - dotenv.main - WARNING - python-dotenv could not parse statement starting at line 10
```

### Solution
- **MCP server**: Removed the upward search fallback; now only checks `.env.local` and `.env` in the current working directory
- **CLI**: Added explicit file existence check before loading `.env`, preventing upward search
- Log info message when no `.env` file is found (not a warning)

### Changes
- `src/mcp_ticketer/mcp/server/main.py`: Removed fallback `load_dotenv(override=True)` call
- `src/mcp_ticketer/cli/main.py`: Added explicit `.env` file check before loading

## Test plan
- [x] Unit test suite passes (411 passed, 12 skipped)
- [x] Import from `/tmp` directory shows no warnings
- [x] Import from project directory correctly loads `.env.local`
- [x] MCP server startup works without warnings
- [x] CLI config commands work correctly

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)