### PR TITLE
fix: add credential re-entry on validation failure

### DIFF
--- a/src/mcp_ticketer/cli/configure.py
+++ b/src/mcp_ticketer/cli/configure.py
@@ -74,6 +74,7 @@ def _mask_sensitive_value(value: str, show_chars: int = 8) -> str:
 def _validate_api_credentials(
     adapter_type: str,
     credentials: dict[str, str],
+    credential_prompter: Callable[[], dict[str, str]] | None = None,
     max_retries: int = 3,
 ) -> bool:
     """Validate API credentials with real API calls.
@@ -82,6 +83,7 @@ def _validate_api_credentials(
     ----
         adapter_type: Type of adapter (linear, github, jira)
         credentials: Dictionary with adapter-specific credentials
+        credential_prompter: Optional callback to re-prompt for credentials on failure
         max_retries: Maximum retry attempts on validation failure
 
     Returns:
@@ -207,7 +209,11 @@ def _validate_api_credentials(
         # Ask user if they want to retry
         if attempt < max_retries:
             retry = Confirm.ask("Re-enter credentials and try again?", default=True)
-            if not retry:
+            if retry and credential_prompter:
+                # Re-prompt for fresh credentials
+                new_credentials = credential_prompter()
+                credentials.update(new_credentials)
+            elif not retry:
                 console.print(
                     "[yellow]Skipping validation. Configuration saved but may not work.[/yellow]"
                 )
@@ -483,10 +489,20 @@ def _configure_linear(
             final_api_key = _retry_setting("API Key", prompt_api_key, validate_api_key)
 
             # Validate API key with real API call
+            def prompt_new_api_key() -> dict[str, str]:
+                """Re-prompt for API key on validation failure."""
+                new_key = Prompt.ask("Linear API Key", password=True)
+                return {"api_key": new_key}
+
             try:
+                credentials = {"api_key": final_api_key}
                 api_key_validated = _validate_api_credentials(
-                    "linear", {"api_key": final_api_key}
+                    "linear",
+                    credentials,
+                    credential_prompter=prompt_new_api_key,
                 )
+                # Update final_api_key with potentially updated value
+                final_api_key = credentials["api_key"]
             except typer.Exit:
                 # User cancelled, propagate the exit
                 raise
@@ -806,15 +822,27 @@ def _configure_jira(
                 final_api_token = Prompt.ask("JIRA API Token", password=True)
 
             # Validate JIRA credentials with real API call
+            def prompt_new_jira_credentials() -> dict[str, str]:
+                """Re-prompt for JIRA credentials on validation failure."""
+                console.print(
+                    "[dim]Generate token at: https://id.atlassian.com/manage/api-tokens[/dim]"
+                )
+                new_token = Prompt.ask("JIRA API Token", password=True)
+                return {"api_token": new_token}
+
             try:
+                credentials = {
+                    "server": final_server,
+                    "email": final_email,
+                    "api_token": final_api_token,
+                }
                 jira_validated = _validate_api_credentials(
                     "jira",
-                    {
-                        "server": final_server,
-                        "email": final_email,
-                        "api_token": final_api_token,
-                    },
+                    credentials,
+                    credential_prompter=prompt_new_jira_credentials,
                 )
+                # Update final_api_token with potentially updated value
+                final_api_token = credentials["api_token"]
             except typer.Exit:
                 # User cancelled, propagate the exit
                 raise
@@ -1012,10 +1040,24 @@ def _configure_github(
                     )
 
             # Validate GitHub token with real API call
-            try:
-                github_validated = _validate_api_credentials(
-                    "github", {"token": final_token}
+            def prompt_new_github_token() -> dict[str, str]:
+                """Re-prompt for GitHub token on validation failure."""
+                console.print(
+                    "[dim]Create token at: https://github.com/settings/tokens/new[/dim]"
                 )
+                console.print(
+                    "[dim]Required scopes: repo (or public_repo for public repos)[/dim]"
+                )
+                new_token = Prompt.ask("GitHub Personal Access Token", password=True)
+                return {"token": new_token}
+
+            try:
+                credentials = {"token": final_token}
+                github_validated = _validate_api_credentials(
+                    "github", credentials, credential_prompter=prompt_new_github_token
+                )
+                # Update final_token with potentially updated value
+                final_token = credentials["token"]
             except typer.Exit:
                 # User cancelled, propagate the exit
                 raise

--- a/tests/cli/test_credential_validation.py
+++ b/tests/cli/test_credential_validation.py
@@ -1,0 +1,237 @@
+"""Tests for credential validation and re-entry functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import typer
+
+from mcp_ticketer.cli.configure import _validate_api_credentials
+
+
+class TestCredentialValidation:
+    """Test credential validation with re-entry on failure."""
+
+    @patch("mcp_ticketer.cli.configure.httpx.post")
+    @patch("mcp_ticketer.cli.configure.Confirm.ask")
+    def test_linear_retry_with_credential_prompter(
+        self, mock_confirm: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Test that Linear validation re-prompts for credentials on retry."""
+        # First attempt: 401 unauthorized (bad token)
+        mock_post.side_effect = [
+            MagicMock(
+                status_code=401,
+                text="Unauthorized",
+            ),
+            # Second attempt: Success (good token)
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "data": {"viewer": {"id": "user123", "name": "Test User"}}
+                },
+            ),
+        ]
+
+        # User says YES to retry
+        mock_confirm.return_value = True
+
+        # Track credential updates
+        call_count = 0
+
+        def prompter() -> dict[str, str]:
+            nonlocal call_count
+            call_count += 1
+            return {"api_key": "lin_new_good_token"}
+
+        credentials = {"api_key": "lin_bad_token"}
+
+        # Should succeed after one retry
+        result = _validate_api_credentials(
+            "linear",
+            credentials,
+            credential_prompter=prompter,
+            max_retries=3,
+        )
+
+        assert result is True
+        assert call_count == 1  # Prompter called once for retry
+        assert credentials["api_key"] == "lin_new_good_token"  # Updated in-place
+        assert mock_post.call_count == 2  # Two API calls
+
+    @patch("mcp_ticketer.cli.configure.httpx.get")
+    @patch("mcp_ticketer.cli.configure.Confirm.ask")
+    def test_github_retry_with_credential_prompter(
+        self, mock_confirm: MagicMock, mock_get: MagicMock
+    ) -> None:
+        """Test that GitHub validation re-prompts for token on retry."""
+        # First attempt: 401 unauthorized
+        mock_get.side_effect = [
+            MagicMock(status_code=401, text="Bad credentials"),
+            # Second attempt: Success
+            MagicMock(status_code=200, json=lambda: {"login": "testuser", "id": 12345}),
+        ]
+
+        # User says YES to retry
+        mock_confirm.return_value = True
+
+        call_count = 0
+
+        def prompter() -> dict[str, str]:
+            nonlocal call_count
+            call_count += 1
+            return {"token": "ghp_new_good_token"}
+
+        credentials = {"token": "ghp_bad_token"}
+
+        result = _validate_api_credentials(
+            "github",
+            credentials,
+            credential_prompter=prompter,
+            max_retries=3,
+        )
+
+        assert result is True
+        assert call_count == 1
+        assert credentials["token"] == "ghp_new_good_token"
+        assert mock_get.call_count == 2
+
+    @patch("mcp_ticketer.cli.configure.httpx.get")
+    @patch("mcp_ticketer.cli.configure.Confirm.ask")
+    def test_jira_retry_with_credential_prompter(
+        self, mock_confirm: MagicMock, mock_get: MagicMock
+    ) -> None:
+        """Test that JIRA validation re-prompts for token on retry."""
+        # First attempt: 401 unauthorized
+        mock_get.side_effect = [
+            MagicMock(status_code=401, text="Unauthorized"),
+            # Second attempt: Success
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "displayName": "Test User",
+                    "emailAddress": "test@example.com",
+                },
+            ),
+        ]
+
+        # User says YES to retry
+        mock_confirm.return_value = True
+
+        call_count = 0
+
+        def prompter() -> dict[str, str]:
+            nonlocal call_count
+            call_count += 1
+            return {"api_token": "new_good_token"}
+
+        credentials = {
+            "server": "https://example.atlassian.net",
+            "email": "test@example.com",
+            "api_token": "bad_token",
+        }
+
+        result = _validate_api_credentials(
+            "jira",
+            credentials,
+            credential_prompter=prompter,
+            max_retries=3,
+        )
+
+        assert result is True
+        assert call_count == 1
+        assert credentials["api_token"] == "new_good_token"
+        assert mock_get.call_count == 2
+
+    @patch("mcp_ticketer.cli.configure.httpx.post")
+    @patch("mcp_ticketer.cli.configure.Confirm.ask")
+    def test_retry_without_prompter_skips_validation(
+        self, mock_confirm: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Test that retry without prompter prompts user to skip validation."""
+        # Both attempts fail with same credentials
+        mock_post.side_effect = [
+            MagicMock(status_code=401, text="Unauthorized"),
+            MagicMock(status_code=401, text="Unauthorized"),
+        ]
+
+        # User says YES to retry (but no prompter provided)
+        # Then user chooses to skip validation (return False)
+        mock_confirm.side_effect = [True, False]  # Retry=Yes, Skip validation=No
+
+        credentials = {"api_key": "lin_bad_token"}
+
+        # Should return True (skip validation) when user says NO to retry
+        result = _validate_api_credentials(
+            "linear",
+            credentials,
+            credential_prompter=None,  # No prompter
+            max_retries=3,
+        )
+
+        assert result is True  # Validation skipped
+        assert credentials["api_key"] == "lin_bad_token"  # Unchanged
+        assert mock_post.call_count == 2  # Two attempts before skip
+
+    @patch("mcp_ticketer.cli.configure.httpx.post")
+    @patch("mcp_ticketer.cli.configure.Confirm.ask")
+    def test_user_declines_retry(
+        self, mock_confirm: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Test that user can decline retry and skip validation."""
+        # First attempt fails
+        mock_post.return_value = MagicMock(status_code=401, text="Unauthorized")
+
+        # User says NO to retry
+        mock_confirm.return_value = False
+
+        credentials = {"api_key": "lin_bad_token"}
+
+        # Should return True (skip validation)
+        result = _validate_api_credentials(
+            "linear",
+            credentials,
+            credential_prompter=lambda: {"api_key": "new_token"},
+            max_retries=3,
+        )
+
+        assert result is True  # Skipped validation
+        assert credentials["api_key"] == "lin_bad_token"  # Unchanged
+        assert mock_post.call_count == 1  # Only one attempt
+
+    @patch("mcp_ticketer.cli.configure.httpx.post")
+    @patch("mcp_ticketer.cli.configure.Confirm.ask")
+    def test_max_retries_exhausted_saves_anyway(
+        self, mock_confirm: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Test behavior when max retries exhausted."""
+        # All attempts fail
+        mock_post.return_value = MagicMock(status_code=401, text="Unauthorized")
+
+        # User says YES to all retries, then YES to save anyway
+        mock_confirm.side_effect = [
+            True,  # Retry attempt 2
+            True,  # Retry attempt 3
+            True,  # Save anyway after max retries
+        ]
+
+        call_count = 0
+
+        def prompter() -> dict[str, str]:
+            nonlocal call_count
+            call_count += 1
+            return {"api_key": f"lin_attempt_{call_count}"}
+
+        credentials = {"api_key": "lin_bad_token"}
+
+        result = _validate_api_credentials(
+            "linear",
+            credentials,
+            credential_prompter=prompter,
+            max_retries=3,
+        )
+
+        assert result is True  # Saved despite failure
+        assert call_count == 2  # Called for attempts 2 and 3
+        assert mock_post.call_count == 3  # Three API calls
+        assert credentials["api_key"] == "lin_attempt_2"  # Last updated value


### PR DESCRIPTION
## Summary

Fixes the bug where `mcp-ticketer setup` would retry API validation with the **same invalid credentials** instead of prompting for new ones when the user said "yes" to re-enter.

### Problem
```
1. User enters token: ghp_bad_token
2. Validation fails: 401 Unauthorized
3. "Re-enter credentials and try again?" → user says YES
4. BUG: Retries with same ghp_bad_token (never prompts!)
5. Fails again...
```

### Solution
Added a `credential_prompter` callback pattern to `_validate_api_credentials()` that enables re-prompting for fresh credentials on validation failure.

```
1. User enters token: ghp_bad_token
2. Validation fails: 401 Unauthorized
3. "Re-enter credentials and try again?" → user says YES
4. FIX: Prompts for new token
5. User enters: ghp_good_token
6. Validation succeeds ✅
```

## Changes

- **`src/mcp_ticketer/cli/configure.py`**: Added `credential_prompter` callback parameter to `_validate_api_credentials()` and updated all adapter config functions (Linear, GitHub, JIRA) to provide credential prompters
- **`tests/cli/test_credential_validation.py`**: Added 6 test cases covering all retry scenarios

## Test plan
- [x] Unit tests pass (6 new tests)
- [x] Manual testing with bad/good token flow
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)