### PR TITLE
feat: support tokens from config file without env vars (#47)

### DIFF
--- a/src/mcp_ticketer/adapters/jira/client.py
+++ b/src/mcp_ticketer/adapters/jira/client.py
@@ -53,8 +53,13 @@ class JiraClient:
         self.timeout = timeout
         self.max_retries = max_retries
 
-        # HTTP client setup
-        self.auth = httpx.BasicAuth(self.email, self.api_token)
+        # HTTP client setup - only create auth if credentials are present
+        # (validate_credentials() will check for missing credentials)
+        self.auth = (
+            httpx.BasicAuth(self.email, self.api_token)
+            if self.email and self.api_token
+            else None
+        )
         self.headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",

--- a/src/mcp_ticketer/adapters/linear/adapter.py
+++ b/src/mcp_ticketer/adapters/linear/adapter.py
@@ -123,16 +123,12 @@ class LinearAdapter(BaseAdapter[Task]):
 
         super().__init__(config)
 
-        # Extract configuration
+        # Extract configuration - don't raise here, validate_credentials() will check
         self.api_key = config.get("api_key") or os.getenv("LINEAR_API_KEY")
-        if not self.api_key:
-            raise ValueError(
-                "Linear API key is required (api_key or LINEAR_API_KEY env var)"
-            )
 
         # Clean API key - remove common prefixes if accidentally included in config
         # (The client will add Bearer back when making requests)
-        if isinstance(self.api_key, str):
+        if self.api_key:
             # Remove Bearer prefix
             if self.api_key.startswith("Bearer "):
                 self.api_key = self.api_key.replace("Bearer ", "")

--- a/src/mcp_ticketer/core/config.py
+++ b/src/mcp_ticketer/core/config.py
@@ -47,13 +47,17 @@ class GitHubConfig(BaseAdapterConfig):
 
     @field_validator("token", mode="before")
     @classmethod
-    def validate_token(cls, v: Any) -> str:
-        """Validate GitHub token from config or environment."""
+    def validate_token(cls, v: Any) -> str | None:
+        """Resolve GitHub token from config or environment.
+
+        Token resolution order:
+        1. Explicit value from config file
+        2. GITHUB_TOKEN environment variable
+        3. None (adapter will validate and provide clear error)
+        """
         if not v:
             v = os.getenv("GITHUB_TOKEN")
-        if not v:
-            raise ValueError("GitHub token is required")
-        return cast(str, v)
+        return cast(str, v) if v else None
 
     @field_validator("owner", mode="before")
     @classmethod
@@ -109,13 +113,17 @@ class JiraConfig(BaseAdapterConfig):
 
     @field_validator("api_token", mode="before")
     @classmethod
-    def validate_api_token(cls, v: Any) -> str:
-        """Validate JIRA API token from config or environment."""
+    def validate_api_token(cls, v: Any) -> str | None:
+        """Resolve JIRA API token from config or environment.
+
+        API token resolution order:
+        1. Explicit value from config file
+        2. JIRA_API_TOKEN environment variable
+        3. None (adapter will validate and provide clear error)
+        """
         if not v:
             v = os.getenv("JIRA_API_TOKEN")
-        if not v:
-            raise ValueError("JIRA API token is required")
-        return cast(str, v)
+        return cast(str, v) if v else None
 
 
 class LinearConfig(BaseAdapterConfig):
@@ -137,13 +145,17 @@ class LinearConfig(BaseAdapterConfig):
 
     @field_validator("api_key", mode="before")
     @classmethod
-    def validate_api_key(cls, v: Any) -> str:
-        """Validate Linear API key from config or environment."""
+    def validate_api_key(cls, v: Any) -> str | None:
+        """Resolve Linear API key from config or environment.
+
+        API key resolution order:
+        1. Explicit value from config file
+        2. LINEAR_API_KEY environment variable
+        3. None (adapter will validate and provide clear error)
+        """
         if not v:
             v = os.getenv("LINEAR_API_KEY")
-        if not v:
-            raise ValueError("Linear API key is required")
-        return cast(str, v)
+        return cast(str, v) if v else None
 
 
 class AITrackdownConfig(BaseAdapterConfig):

--- a/src/mcp_ticketer/core/env_loader.py
+++ b/src/mcp_ticketer/core/env_loader.py
@@ -41,7 +41,7 @@ class UnifiedEnvLoader:
             primary_key="LINEAR_API_KEY",
             aliases=["LINEAR_TOKEN", "LINEAR_ACCESS_TOKEN", "LINEAR_AUTH_TOKEN"],
             description="Linear API key",
-            required=True,
+            required=False,  # Adapter validates credentials, not env_loader
         ),
         "linear_team_id": EnvKeyConfig(
             primary_key="LINEAR_TEAM_ID",
@@ -77,7 +77,7 @@ class UnifiedEnvLoader:
                 "JIRA_PASSWORD",
             ],
             description="JIRA API token",
-            required=True,
+            required=False,  # Adapter validates credentials, not env_loader
         ),
         "jira_project_key": EnvKeyConfig(
             primary_key="JIRA_PROJECT_KEY",
@@ -90,7 +90,7 @@ class UnifiedEnvLoader:
             primary_key="GITHUB_TOKEN",
             aliases=["GITHUB_ACCESS_TOKEN", "GITHUB_API_TOKEN", "GITHUB_AUTH_TOKEN"],
             description="GitHub access token",
-            required=True,
+            required=False,  # Adapter validates credentials, not env_loader
         ),
         "github_owner": EnvKeyConfig(
             primary_key="GITHUB_OWNER",

--- a/tests/core/test_config_token_resolution.py
+++ b/tests/core/test_config_token_resolution.py
@@ -1,0 +1,332 @@
+"""Test token resolution from config file vs environment variables.
+
+This test module verifies that tokens can be loaded from:
+1. Config file only (no env var)
+2. Environment variable only (no config)
+3. Both (env var takes precedence)
+4. Neither (should fail at adapter validation, not config parsing)
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mcp_ticketer.core.config import (
+    GitHubConfig,
+    JiraConfig,
+    LinearConfig,
+)
+
+
+class TestGitHubTokenResolution:
+    """Test GitHub token resolution from config and environment."""
+
+    def test_token_from_config_only(self) -> None:
+        """Test loading token from config file when env var not set."""
+        # Ensure GITHUB_TOKEN is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "GITHUB_TOKEN" in os.environ:
+                del os.environ["GITHUB_TOKEN"]
+
+            # Create config with token
+            config = GitHubConfig(
+                token="ghp_config_token_123",
+                owner="test-owner",
+                repo="test-repo",
+            )
+
+            assert config.token == "ghp_config_token_123"
+            assert config.owner == "test-owner"
+            assert config.repo == "test-repo"
+
+    def test_token_from_env_only(self) -> None:
+        """Test loading token from environment when config has None."""
+        # Set GITHUB_TOKEN in environment
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "ghp_env_token_456"}, clear=False
+        ):
+            # Create config without token (should resolve from env)
+            config = GitHubConfig(
+                token=None,
+                owner="test-owner",
+                repo="test-repo",
+            )
+
+            assert config.token == "ghp_env_token_456"
+            assert config.owner == "test-owner"
+            assert config.repo == "test-repo"
+
+    def test_token_env_takes_precedence(self) -> None:
+        """Test that environment variable takes precedence over config.
+
+        Note: Current implementation prioritizes config over env.
+        This test documents the actual behavior.
+        """
+        # Set GITHUB_TOKEN in environment
+        with mock.patch.dict(
+            os.environ, {"GITHUB_TOKEN": "ghp_env_token_789"}, clear=False
+        ):
+            # Create config with explicit token (should use config value)
+            config = GitHubConfig(
+                token="ghp_config_token_999",
+                owner="test-owner",
+                repo="test-repo",
+            )
+
+            # Config value takes precedence (not env var)
+            assert config.token == "ghp_config_token_999"
+
+    def test_no_token_returns_none(self) -> None:
+        """Test that missing token returns None (validation happens at adapter)."""
+        # Ensure GITHUB_TOKEN is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "GITHUB_TOKEN" in os.environ:
+                del os.environ["GITHUB_TOKEN"]
+
+            # Create config without token
+            config = GitHubConfig(
+                token=None,
+                owner="test-owner",
+                repo="test-repo",
+            )
+
+            # Should be None, not raise ValueError
+            assert config.token is None
+            assert config.owner == "test-owner"
+            assert config.repo == "test-repo"
+
+
+class TestLinearTokenResolution:
+    """Test Linear API key resolution from config and environment."""
+
+    def test_api_key_from_config_only(self) -> None:
+        """Test loading API key from config file when env var not set."""
+        # Ensure LINEAR_API_KEY is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "LINEAR_API_KEY" in os.environ:
+                del os.environ["LINEAR_API_KEY"]
+
+            # Create config with api_key
+            config = LinearConfig(
+                api_key="lin_config_key_123",
+                team_key="ENG",
+            )
+
+            assert config.api_key == "lin_config_key_123"
+            assert config.team_key == "ENG"
+
+    def test_api_key_from_env_only(self) -> None:
+        """Test loading API key from environment when config has None."""
+        # Set LINEAR_API_KEY in environment
+        with mock.patch.dict(
+            os.environ, {"LINEAR_API_KEY": "lin_env_key_456"}, clear=False
+        ):
+            # Create config without api_key (should resolve from env)
+            config = LinearConfig(
+                api_key=None,
+                team_key="ENG",
+            )
+
+            assert config.api_key == "lin_env_key_456"
+            assert config.team_key == "ENG"
+
+    def test_api_key_env_precedence(self) -> None:
+        """Test token precedence (config vs env).
+
+        Current implementation: config takes precedence over env.
+        """
+        # Set LINEAR_API_KEY in environment
+        with mock.patch.dict(
+            os.environ, {"LINEAR_API_KEY": "lin_env_key_789"}, clear=False
+        ):
+            # Create config with explicit api_key
+            config = LinearConfig(
+                api_key="lin_config_key_999",
+                team_key="ENG",
+            )
+
+            # Config value takes precedence
+            assert config.api_key == "lin_config_key_999"
+
+    def test_no_api_key_returns_none(self) -> None:
+        """Test that missing API key returns None (validation happens at adapter)."""
+        # Ensure LINEAR_API_KEY is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "LINEAR_API_KEY" in os.environ:
+                del os.environ["LINEAR_API_KEY"]
+
+            # Create config without api_key
+            config = LinearConfig(
+                api_key=None,
+                team_key="ENG",
+            )
+
+            # Should be None, not raise ValueError
+            assert config.api_key is None
+            assert config.team_key == "ENG"
+
+
+class TestJiraTokenResolution:
+    """Test JIRA API token resolution from config and environment."""
+
+    def test_api_token_from_config_only(self) -> None:
+        """Test loading API token from config file when env var not set."""
+        # Ensure JIRA_API_TOKEN is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "JIRA_API_TOKEN" in os.environ:
+                del os.environ["JIRA_API_TOKEN"]
+
+            # Create config with api_token
+            config = JiraConfig(
+                server="https://test.atlassian.net",
+                email="test@example.com",
+                api_token="jira_config_token_123",
+            )
+
+            assert config.api_token == "jira_config_token_123"
+            assert config.server == "https://test.atlassian.net"
+            assert config.email == "test@example.com"
+
+    def test_api_token_from_env_only(self) -> None:
+        """Test loading API token from environment when config has None."""
+        # Set JIRA_API_TOKEN in environment
+        with mock.patch.dict(
+            os.environ, {"JIRA_API_TOKEN": "jira_env_token_456"}, clear=False
+        ):
+            # Create config without api_token (should resolve from env)
+            config = JiraConfig(
+                server="https://test.atlassian.net",
+                email="test@example.com",
+                api_token=None,
+            )
+
+            assert config.api_token == "jira_env_token_456"
+            assert config.server == "https://test.atlassian.net"
+            assert config.email == "test@example.com"
+
+    def test_api_token_env_precedence(self) -> None:
+        """Test token precedence (config vs env).
+
+        Current implementation: config takes precedence over env.
+        """
+        # Set JIRA_API_TOKEN in environment
+        with mock.patch.dict(
+            os.environ, {"JIRA_API_TOKEN": "jira_env_token_789"}, clear=False
+        ):
+            # Create config with explicit api_token
+            config = JiraConfig(
+                server="https://test.atlassian.net",
+                email="test@example.com",
+                api_token="jira_config_token_999",
+            )
+
+            # Config value takes precedence
+            assert config.api_token == "jira_config_token_999"
+
+    def test_no_api_token_returns_none(self) -> None:
+        """Test that missing API token returns None (validation happens at adapter)."""
+        # Ensure JIRA_API_TOKEN is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "JIRA_API_TOKEN" in os.environ:
+                del os.environ["JIRA_API_TOKEN"]
+
+            # Create config without api_token
+            config = JiraConfig(
+                server="https://test.atlassian.net",
+                email="test@example.com",
+                api_token=None,
+            )
+
+            # Should be None, not raise ValueError
+            assert config.api_token is None
+            assert config.server == "https://test.atlassian.net"
+            assert config.email == "test@example.com"
+
+
+class TestAdapterValidation:
+    """Test that adapter validation still works properly.
+
+    These tests verify that adapters raise clear errors when tokens are missing,
+    ensuring that config parsing no longer blocks initialization but adapters
+    still enforce credential requirements.
+    """
+
+    def test_github_adapter_validates_missing_token(self) -> None:
+        """Test that GitHub adapter validates missing token."""
+        # Import here to avoid circular dependencies
+        from mcp_ticketer.adapters.github.adapter import GitHubAdapter
+
+        # Ensure GITHUB_TOKEN is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "GITHUB_TOKEN" in os.environ:
+                del os.environ["GITHUB_TOKEN"]
+
+            # Create adapter config without token
+            config = {
+                "token": None,
+                "owner": "test-owner",
+                "repo": "test-repo",
+            }
+
+            # Adapter initialization should succeed
+            adapter = GitHubAdapter(config)
+
+            # But validate_credentials should fail
+            is_valid, error_msg = adapter.validate_credentials()
+            assert not is_valid
+            assert "GITHUB_TOKEN" in error_msg
+
+    def test_linear_adapter_validates_missing_api_key(self) -> None:
+        """Test that Linear adapter validates missing API key."""
+        # Import here to avoid circular dependencies
+        from mcp_ticketer.adapters.linear.adapter import LinearAdapter
+
+        # Ensure LINEAR_API_KEY is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "LINEAR_API_KEY" in os.environ:
+                del os.environ["LINEAR_API_KEY"]
+
+            # Create adapter config without api_key
+            config = {
+                "api_key": None,
+                "team_key": "ENG",
+            }
+
+            # Adapter initialization should succeed
+            adapter = LinearAdapter(config)
+
+            # But validate_credentials should fail
+            is_valid, error_msg = adapter.validate_credentials()
+            assert not is_valid
+            assert "API key" in error_msg or "api_key" in error_msg.lower()
+
+    def test_jira_adapter_validates_missing_api_token(self) -> None:
+        """Test that JIRA adapter validates missing API token."""
+        # Import here to avoid circular dependencies
+        from mcp_ticketer.adapters.jira.adapter import JiraAdapter
+
+        # Ensure JIRA_API_TOKEN is not in environment
+        with mock.patch.dict(os.environ, {}, clear=False):
+            if "JIRA_API_TOKEN" in os.environ:
+                del os.environ["JIRA_API_TOKEN"]
+
+            # Create adapter config without api_token
+            config = {
+                "server": "https://test.atlassian.net",
+                "email": "test@example.com",
+                "api_token": None,
+            }
+
+            # Adapter initialization should succeed
+            adapter = JiraAdapter(config)
+
+            # But validate_credentials should fail
+            is_valid, error_msg = adapter.validate_credentials()
+            assert not is_valid
+            # Error message should mention token/credentials
+            assert (
+                "token" in error_msg.lower() or "credential" in error_msg.lower()
+            )


### PR DESCRIPTION
## Summary
- Tokens in config.json are now properly loaded when environment variables are not set
- This allows users to store credentials in config files for deployment scenarios where env vars aren't preferred

## Problem
Previously, the Pydantic validators would raise `ValueError` if environment variables weren't set, even when tokens were explicitly provided in the config file. This blocked config-file-only credential storage.

## Solution
Token resolution order is now:
1. **Explicit config value** (if provided in config.json)
2. **Environment variable** (if config is None/empty)
3. **None** (adapter validates credentials later)

## Changes
- **`src/mcp_ticketer/core/config.py`**: Updated 3 Pydantic validators (GitHub, Linear, JIRA) to return `str | None` instead of raising ValueError
- **`src/mcp_ticketer/core/env_loader.py`**: Marked token keys as `required=False`
- **`src/mcp_ticketer/adapters/linear/adapter.py`**: Guard against None api_key
- **`src/mcp_ticketer/adapters/jira/client.py`**: Made BasicAuth conditional on credentials

## Test plan
- [x] 15 new tests added in `tests/core/test_config_token_resolution.py`
- [x] Tests cover all three adapters (GitHub, Linear, JIRA)
- [x] Tests verify config-only, env-only, precedence, and no-token scenarios
- [x] All tests pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)