### PR TITLE
Add Plane.so backend adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,36 @@ JIRA_PROJECT_KEY=PROJ
 # MCP_TICKETER_JIRA_SERVER=...
 
 # ============================================================================
+# Plane Configuration
+# ============================================================================
+# Plane (https://plane.so) is self-hostable and also offered as a cloud SaaS.
+# Generate a personal API key from: Workspace Settings → API Tokens
+PLANE_API_KEY=plane_api_YOUR_KEY_HERE
+
+# Plane instance URL (optional - defaults to https://api.plane.so for cloud).
+# For self-hosted instances, point this at your deployment.
+# Must be an https:// URL (the API key is sent in the X-API-Key header).
+# PLANE_INSTANCE_URL=https://plane.example.com
+
+# Plane workspace slug (required - the short slug in your Plane URLs,
+# e.g. https://app.plane.so/<workspace-slug>/)
+PLANE_WORKSPACE_SLUG=your-workspace-slug
+
+# Plane project ID (required - the project UUID; find it in the project URL
+# or via the API)
+PLANE_PROJECT_ID=00000000-0000-0000-0000-000000000000
+
+# Alternative naming conventions also supported:
+# PLANE_TOKEN=...
+# PLANE_KEY=...
+# PLANE_URL=...
+# PLANE_WORKSPACE=...
+# PLANE_PROJECT=...
+# MCP_TICKETER_PLANE_API_KEY=...
+# MCP_TICKETER_PLANE_WORKSPACE_SLUG=...
+# MCP_TICKETER_PLANE_PROJECT_ID=...
+
+# ============================================================================
 # AITrackdown Configuration
 # ============================================================================
 # Base path for local ticket storage (defaults to .aitrackdown)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Universal ticket management interface for AI agents with MCP (Model Context Prot
 ## 🚀 Features
 
 - **🎯 Universal Ticket Model**: Simplified to Epic, Task, and Comment types
-- **🔌 Multiple Adapters**: Support for JIRA, Linear, GitHub Issues, and AI-Trackdown
+- **🔌 Multiple Adapters**: Support for JIRA, Linear, GitHub Issues, Asana, Plane, and AI-Trackdown
 - **🤖 MCP Integration**: Native support for AI agent interactions
 - **⚡ High Performance**: Smart caching and async operations
 - **🎨 Rich CLI**: Beautiful terminal interface with colors and tables
@@ -53,7 +53,27 @@ pip install mcp-ticketer[linear]    # Linear support
 pip install mcp-ticketer[github]    # GitHub Issues support
 pip install mcp-ticketer[analysis]  # PM monitoring tools
 pip install mcp-ticketer[all]       # All adapters and features
+
+# Note: the Asana and Plane adapters use the bundled httpx client and
+# require no extra — they work with the base `pip install mcp-ticketer`.
 ```
+
+### Plane
+
+Plane (https://plane.so, self-hostable) is configured with an API key,
+workspace slug, and project ID:
+
+```bash
+export PLANE_API_KEY=plane_api_...           # Workspace Settings → API Tokens
+export PLANE_WORKSPACE_SLUG=your-workspace   # slug from your Plane URL
+export PLANE_PROJECT_ID=<project-uuid>       # project UUID
+# Optional - defaults to https://api.plane.so; set for self-hosted instances:
+# export PLANE_INSTANCE_URL=https://plane.example.com   # must be https
+```
+
+The Plane adapter maps Epics to Plane projects, Issues/Tasks to Plane issues
+and sub-issues, and Milestones to Plane modules. See `.env.example` for the
+full list of supported variable names.
 
 **Note (v0.15.0+)**: The `setup` command now automatically detects and installs adapter dependencies! When you run `mcp-ticketer setup`, it will prompt you to install any missing adapter-specific dependencies, eliminating the need for manual `pip install mcp-ticketer[adapter]` after setup.
 

--- a/src/mcp_ticketer/adapters/__init__.py
+++ b/src/mcp_ticketer/adapters/__init__.py
@@ -6,6 +6,7 @@ from .github import GitHubAdapter
 from .hybrid import HybridAdapter
 from .jira import JiraAdapter
 from .linear import LinearAdapter
+from .plane import PlaneAdapter
 
 __all__ = [
     "AITrackdownAdapter",
@@ -14,4 +15,5 @@ __all__ = [
     "JiraAdapter",
     "GitHubAdapter",
     "HybridAdapter",
+    "PlaneAdapter",
 ]

--- a/src/mcp_ticketer/adapters/plane/__init__.py
+++ b/src/mcp_ticketer/adapters/plane/__init__.py
@@ -1,0 +1,17 @@
+"""Plane adapter for mcp-ticketer.
+
+This adapter integrates with Plane (https://plane.so, self-hostable) via its
+REST API v1, supporting:
+
+- CRUD operations for issues (and sub-issues)
+- Epic operations mapped to Plane projects
+- Real workflow-state transitions via Plane's per-project states
+- Assignee resolution against workspace members
+- Label resolution and creation
+- Comments
+- Milestones mapped to Plane modules
+"""
+
+from .adapter import PlaneAdapter
+
+__all__ = ["PlaneAdapter"]

--- a/src/mcp_ticketer/adapters/plane/adapter.py
+++ b/src/mcp_ticketer/adapters/plane/adapter.py
@@ -1,0 +1,1078 @@
+"""Main PlaneAdapter class for Plane REST API v1 integration.
+
+This adapter integrates with Plane (https://plane.so, self-hostable) via its
+REST API. It supports the full ``BaseAdapter`` contract:
+
+- CRUD on issues (universal Task / Issue)
+- Epic operations mapped to Plane projects (read-only project listing)
+- Real workflow-state transitions via Plane's per-project states
+- Assignee resolution against workspace members
+- Label resolution / creation
+- Comments via the issue comments endpoint
+- Milestones mapped to Plane *modules*
+
+Hierarchy mapping
+-----------------
+- Epic  -> Plane project (the adapter is scoped to one project; project
+  listing/reads are supported, but project creation is delegated to Plane's
+  UI/admin API and is therefore not implemented here).
+- Issue -> Plane issue with no ``parent``.
+- Task  -> Plane sub-issue (an issue whose ``parent`` is another issue).
+
+Unimplemented surfaces
+----------------------
+- ``project_create`` / ``project_update`` / ``project_delete``: project
+  lifecycle in Plane is an admin operation outside the per-project API key
+  scope; these raise ``NotImplementedError``.
+- File attachments: Plane's asset-upload flow is a multi-step S3 presign that
+  is out of scope for this adapter; the inherited ``NotImplementedError``
+  behaviour is kept.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+from ...core.adapter import BaseAdapter
+from ...core.models import (
+    Comment,
+    Epic,
+    Milestone,
+    Project,
+    ProjectScope,
+    ProjectState,
+    SearchQuery,
+    Task,
+    TicketState,
+    TicketType,
+)
+from ...core.registry import AdapterRegistry
+from .client import PlaneClient
+from .mappers import (
+    map_plane_comment_to_comment,
+    map_plane_issue_to_task,
+    map_plane_module_to_milestone,
+    map_plane_project_to_epic,
+    map_task_to_plane_issue,
+)
+from .types import STATE_TO_GROUP, PlaneStateGroup
+
+logger = logging.getLogger(__name__)
+
+
+class PlaneAdapter(BaseAdapter[Task]):
+    """Adapter for Plane issue management using the REST API v1.
+
+    The adapter is scoped to a single workspace + project, configured via the
+    ``workspace_slug`` and ``project_id`` config keys (or the corresponding
+    environment variables).
+    """
+
+    def __init__(self, config: dict[str, Any]):
+        """Initialise the Plane adapter.
+
+        Args:
+            config: Configuration with:
+                - api_key: Plane API key (or PLANE_API_KEY env var).
+                - instance_url: Plane instance URL (default https://api.plane.so).
+                - workspace_slug: Plane workspace slug (or PLANE_WORKSPACE_SLUG).
+                - project_id: Plane project UUID (or PLANE_PROJECT_ID).
+                - timeout: Request timeout in seconds (default: 30).
+                - max_retries: Maximum retry attempts (default: 3).
+
+        Raises:
+            ValueError: If required configuration is missing or invalid.
+
+        """
+        # Caches populated lazily on first use.
+        self._states_by_id: dict[str, dict[str, Any]] = {}
+        self._states_loaded = False
+        self._members_loaded = False
+        self._members: list[dict[str, Any]] = []
+        self._initialized = False
+
+        super().__init__(config)
+
+        self.api_key = config.get("api_key") or os.getenv("PLANE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Plane API key is required (api_key or PLANE_API_KEY env var)"
+            )
+
+        self.instance_url = (
+            config.get("instance_url")
+            or os.getenv("PLANE_INSTANCE_URL")
+            or "https://api.plane.so"
+        )
+        self.workspace_slug = config.get("workspace_slug") or os.getenv(
+            "PLANE_WORKSPACE_SLUG"
+        )
+        self.project_id = config.get("project_id") or os.getenv("PLANE_PROJECT_ID")
+
+        if not self.workspace_slug:
+            raise ValueError(
+                "Plane workspace slug is required "
+                "(workspace_slug or PLANE_WORKSPACE_SLUG env var)"
+            )
+        if not self.project_id:
+            raise ValueError(
+                "Plane project ID is required (project_id or PLANE_PROJECT_ID env var)"
+            )
+
+        timeout = config.get("timeout", 30)
+        max_retries = config.get("max_retries", 3)
+
+        # PlaneClient validates the instance URL (https-only) on construction.
+        self.client = PlaneClient(
+            api_key=self.api_key,
+            workspace_slug=self.workspace_slug,
+            project_id=self.project_id,
+            instance_url=self.instance_url,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+    def _get_state_mapping(self) -> dict[TicketState, str]:
+        """Get the universal-state -> Plane state-group mapping.
+
+        Plane resolves a concrete state UUID per project; the coarse group is
+        the stable, project-independent mapping returned here.
+
+        Returns:
+            Dictionary mapping each TicketState to its Plane state-group value.
+
+        """
+        return {state: group.value for state, group in STATE_TO_GROUP.items()}
+
+    def get_available_states(self) -> builtins.list[str]:
+        """Return Plane's state-group names for semantic state matching.
+
+        Returns:
+            List of Plane state-group names.
+
+        """
+        return [group.value for group in PlaneStateGroup]
+
+    def validate_credentials(self) -> tuple[bool, str]:
+        """Validate that required Plane credentials/configuration are present.
+
+        Returns:
+            Tuple of (is_valid, error_message).
+
+        """
+        if not self.api_key:
+            return False, "Plane API key is required"
+        if not self.workspace_slug:
+            return False, "Plane workspace slug is required"
+        if not self.project_id:
+            return False, "Plane project ID is required"
+        return True, ""
+
+    async def initialize(self) -> None:
+        """Verify connectivity and warm the state cache."""
+        if self._initialized:
+            return
+
+        if not await self.client.test_connection():
+            raise ValueError("Failed to connect to Plane API - check credentials")
+
+        await self._load_states()
+        self._initialized = True
+        logger.info(
+            "Plane adapter initialized for workspace '%s' project '%s'",
+            self.workspace_slug,
+            self.project_id,
+        )
+
+    # Resolution helpers -----------------------------------------------------
+
+    async def _load_states(self, force: bool = False) -> dict[str, dict[str, Any]]:
+        """Load and cache the project's states keyed by UUID.
+
+        Args:
+            force: Reload even if already cached.
+
+        Returns:
+            Mapping of state UUID -> state record.
+
+        """
+        if self._states_loaded and not force:
+            return self._states_by_id
+
+        try:
+            states = await self.client.get_paginated("/states/")
+            self._states_by_id = {
+                state["id"]: state for state in states if state.get("id")
+            }
+            self._states_loaded = True
+        except Exception as e:
+            logger.error("Failed to load Plane states: %s", e)
+            self._states_by_id = {}
+
+        return self._states_by_id
+
+    async def resolve_state_id(self, state: TicketState | str) -> str | None:
+        """Resolve a universal state to a concrete Plane state UUID.
+
+        Resolution strategy:
+        1. Prefer a state in the mapped group whose *name* matches the universal
+           state's keywords (so READY/TESTED/etc. land on a named state when the
+           project defines one).
+        2. Otherwise, fall back to the first state in the mapped group.
+
+        Args:
+            state: Universal ticket state. A plain string is accepted because
+                the models use ``use_enum_values=True`` (so ``Task.state`` is a
+                string at runtime).
+
+        Returns:
+            Plane state UUID, or None if no state matches.
+
+        """
+        # Coerce string back to the enum (models store enum *values*).
+        if isinstance(state, str):
+            try:
+                state = TicketState(state)
+            except ValueError:
+                state = TicketState.OPEN
+
+        states = await self._load_states()
+        if not states:
+            return None
+
+        target_group = STATE_TO_GROUP.get(state, PlaneStateGroup.UNSTARTED).value
+        group_states = [s for s in states.values() if s.get("group") == target_group]
+        if not group_states:
+            return None
+
+        # Name-based refinement: try to find a state whose name matches the
+        # universal state's own value (e.g. "blocked", "ready").
+        state_keyword = state.value.replace("_", " ")
+        for candidate in group_states:
+            if state_keyword in (candidate.get("name") or "").lower():
+                return str(candidate["id"])
+
+        # Fall back to the default state in the group, else the first one.
+        for candidate in group_states:
+            if candidate.get("default"):
+                return str(candidate["id"])
+        return str(group_states[0]["id"])
+
+    async def _load_members(self, force: bool = False) -> list[dict[str, Any]]:
+        """Load and cache the workspace members.
+
+        Args:
+            force: Reload even if already cached.
+
+        Returns:
+            List of member records.
+
+        """
+        if self._members_loaded and not force:
+            return self._members
+
+        try:
+            self._members = await self.client.get_paginated(
+                "/members/", workspace_scoped=True
+            )
+            self._members_loaded = True
+        except Exception as e:
+            logger.error("Failed to load Plane members: %s", e)
+            self._members = []
+
+        return self._members
+
+    async def _resolve_user_id(self, user_identifier: str) -> str | None:
+        """Resolve a user identifier (email, display name, or UUID) to a UUID.
+
+        Args:
+            user_identifier: User email, display name, or member/user UUID.
+
+        Returns:
+            User UUID, or None if not resolvable.
+
+        """
+        if not user_identifier:
+            return None
+
+        members = await self._load_members()
+        identifier_lower = user_identifier.lower()
+
+        for member in members:
+            member_obj = member.get("member") or member
+            candidate_ids = {
+                str(member.get("member_id") or ""),
+                str(member.get("id") or ""),
+                str(member_obj.get("id") or ""),
+            }
+            if user_identifier in candidate_ids:
+                return user_identifier
+
+            email = str(member_obj.get("email") or "").lower()
+            display = str(member_obj.get("display_name") or "").lower()
+            if identifier_lower in (email, display) and (email or display):
+                resolved = member.get("member_id") or member_obj.get("id")
+                if resolved:
+                    return str(resolved)
+
+        logger.warning("Could not resolve Plane user '%s'", user_identifier)
+        return None
+
+    async def _resolve_label_ids(self, labels: list[str]) -> list[str]:
+        """Resolve label names to UUIDs, creating any that do not yet exist.
+
+        UUID-shaped values are passed through unchanged.
+
+        Args:
+            labels: Label names (or UUIDs).
+
+        Returns:
+            List of label UUIDs.
+
+        """
+        if not labels:
+            return []
+
+        try:
+            existing = await self.client.get_paginated("/labels/")
+        except Exception as e:
+            logger.warning("Failed to load Plane labels: %s", e)
+            existing = []
+
+        by_name = {
+            str(label.get("name", "")).lower(): str(label["id"])
+            for label in existing
+            if label.get("id")
+        }
+        existing_ids = {str(label["id"]) for label in existing if label.get("id")}
+
+        resolved: list[str] = []
+        for label in labels:
+            if label in existing_ids:
+                resolved.append(label)
+                continue
+
+            label_id = by_name.get(label.lower())
+            if label_id:
+                resolved.append(label_id)
+                continue
+
+            try:
+                created = await self.client.post("/labels/", {"name": label})
+                if created.get("id"):
+                    resolved.append(str(created["id"]))
+            except Exception as e:
+                logger.warning("Failed to create Plane label '%s': %s", label, e)
+
+        return resolved
+
+    # CRUD Operations --------------------------------------------------------
+
+    async def create(self, ticket: Task) -> Task:
+        """Create a Plane issue (or sub-issue) from a Task.
+
+        Args:
+            ticket: Task to create.
+
+        Returns:
+            Created task with its Plane ID populated.
+
+        Raises:
+            ValueError: If credentials are invalid or creation fails.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        await self.initialize()
+
+        if isinstance(ticket, Epic):
+            raise NotImplementedError(
+                "Plane projects (epics) are created via the Plane admin UI/API; "
+                "the per-project adapter cannot create projects. Configure "
+                "project_id and create issues instead."
+            )
+
+        state_id = await self.resolve_state_id(ticket.state)
+
+        assignee_ids: list[str] | None = None
+        if ticket.assignee:
+            resolved = await self._resolve_user_id(ticket.assignee)
+            assignee_ids = [resolved] if resolved else []
+
+        label_ids = await self._resolve_label_ids(ticket.tags) if ticket.tags else None
+
+        payload = map_task_to_plane_issue(
+            ticket,
+            state_id=state_id,
+            assignee_ids=assignee_ids,
+            label_ids=label_ids,
+        )
+
+        try:
+            created = await self.client.post("/issues/", payload)
+            return map_plane_issue_to_task(created, await self._load_states())
+        except Exception as e:
+            raise ValueError(f"Failed to create Plane issue: {e}") from e
+
+    async def read(self, ticket_id: str) -> Task | None:
+        """Read a Plane issue by UUID.
+
+        Args:
+            ticket_id: Plane issue UUID.
+
+        Returns:
+            Task if found, None otherwise.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        try:
+            issue = await self.client.get(f"/issues/{ticket_id}/")
+            return map_plane_issue_to_task(issue, await self._load_states())
+        except Exception as e:
+            logger.error("Failed to read Plane issue %s: %s", ticket_id, e)
+            return None
+
+    async def update(self, ticket_id: str, updates: dict[str, Any]) -> Task | None:
+        """Update a Plane issue.
+
+        Supported update keys: ``title``, ``description``, ``state``,
+        ``priority``, ``assignee``, ``tags``, ``target_date``.
+
+        Args:
+            ticket_id: Plane issue UUID.
+            updates: Fields to update.
+
+        Returns:
+            Updated task, or None on failure.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        from .types import map_priority_to_plane
+
+        payload: dict[str, Any] = {}
+
+        if "title" in updates:
+            payload["name"] = updates["title"]
+
+        if "description" in updates:
+            payload["description_html"] = updates["description"]
+
+        if "priority" in updates:
+            priority = updates["priority"]
+            if isinstance(priority, str):
+                from ...core.models import Priority
+
+                priority = Priority(priority)
+            payload["priority"] = map_priority_to_plane(priority)
+
+        if "state" in updates:
+            state = updates["state"]
+            if isinstance(state, str):
+                state = TicketState(state)
+            state_id = await self.resolve_state_id(state)
+            if state_id:
+                payload["state"] = state_id
+
+        if "assignee" in updates:
+            assignee = updates["assignee"]
+            if assignee:
+                resolved = await self._resolve_user_id(assignee)
+                payload["assignees"] = [resolved] if resolved else []
+            else:
+                payload["assignees"] = []
+
+        if "tags" in updates:
+            payload["labels"] = await self._resolve_label_ids(updates["tags"] or [])
+
+        if "target_date" in updates:
+            payload["target_date"] = updates["target_date"]
+
+        try:
+            if payload:
+                await self.client.patch(f"/issues/{ticket_id}/", payload)
+            issue = await self.client.get(f"/issues/{ticket_id}/")
+            return map_plane_issue_to_task(issue, await self._load_states())
+        except Exception as e:
+            logger.error("Failed to update Plane issue %s: %s", ticket_id, e)
+            return None
+
+    async def delete(self, ticket_id: str) -> bool:
+        """Delete a Plane issue.
+
+        Args:
+            ticket_id: Plane issue UUID.
+
+        Returns:
+            True if deleted, False otherwise.
+
+        """
+        try:
+            await self.client.delete(f"/issues/{ticket_id}/")
+            return True
+        except Exception as e:
+            logger.error("Failed to delete Plane issue %s: %s", ticket_id, e)
+            return False
+
+    async def list(
+        self, limit: int = 10, offset: int = 0, filters: dict[str, Any] | None = None
+    ) -> builtins.list[Task]:
+        """List Plane issues with optional filtering.
+
+        Args:
+            limit: Maximum number of issues to return.
+            offset: Number of issues to skip (applied client-side).
+            filters: Optional filters (state, priority, assignee, parent_issue,
+                ticket_type).
+
+        Returns:
+            List of tasks matching the criteria.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        await self.initialize()
+
+        params: dict[str, Any] = {}
+        if filters:
+            if "priority" in filters:
+                priority = filters["priority"]
+                params["priority"] = getattr(priority, "value", priority)
+
+        try:
+            raw_issues = await self.client.get_paginated("/issues/", params=params)
+        except Exception as e:
+            logger.error("Failed to list Plane issues: %s", e)
+            return []
+
+        states = await self._load_states()
+        tasks = [map_plane_issue_to_task(issue, states) for issue in raw_issues]
+        tasks = self._apply_filters(tasks, filters)
+
+        return tasks[offset : offset + limit]
+
+    def _apply_filters(
+        self, tasks: builtins.list[Task], filters: dict[str, Any] | None
+    ) -> builtins.list[Task]:
+        """Apply client-side filtering not expressible in the list query.
+
+        Args:
+            tasks: Tasks to filter.
+            filters: Filter criteria.
+
+        Returns:
+            Filtered task list.
+
+        """
+        if not filters:
+            return tasks
+
+        if "state" in filters:
+            state = filters["state"]
+            if isinstance(state, str):
+                state = TicketState(state)
+            tasks = [t for t in tasks if t.state == state]
+
+        if "ticket_type" in filters:
+            ticket_type = filters["ticket_type"]
+            tasks = [t for t in tasks if t.ticket_type == ticket_type]
+
+        if "parent_issue" in filters:
+            parent = filters["parent_issue"]
+            tasks = [t for t in tasks if t.parent_issue == parent]
+
+        if "assignee" in filters:
+            assignee = filters["assignee"]
+            tasks = [
+                t
+                for t in tasks
+                if assignee in (t.metadata.get("plane_assignees") or [])
+                or t.assignee == assignee
+            ]
+
+        return tasks
+
+    async def search(self, query: SearchQuery) -> builtins.list[Task]:
+        """Search Plane issues using filters and client-side text matching.
+
+        Args:
+            query: Search query with filters.
+
+        Returns:
+            List of tasks matching the search criteria.
+
+        """
+        filters: dict[str, Any] = {}
+        if query.state:
+            filters["state"] = query.state
+        if query.priority:
+            filters["priority"] = query.priority
+        if query.assignee:
+            filters["assignee"] = query.assignee
+
+        # Fetch generously, then narrow client-side, then page.
+        tasks = await self.list(limit=100, offset=0, filters=filters)
+
+        if query.query:
+            query_lower = query.query.lower()
+            tasks = [
+                t
+                for t in tasks
+                if query_lower in t.title.lower()
+                or (t.description and query_lower in t.description.lower())
+            ]
+
+        if query.tags:
+            tasks = [t for t in tasks if any(tag in t.tags for tag in query.tags)]
+
+        return tasks[query.offset : query.offset + query.limit]
+
+    async def transition_state(
+        self, ticket_id: str, target_state: TicketState
+    ) -> Task | None:
+        """Transition an issue to a new state.
+
+        Args:
+            ticket_id: Plane issue UUID.
+            target_state: Target universal state.
+
+        Returns:
+            Updated task, or None on failure.
+
+        """
+        return await self.update(ticket_id, {"state": target_state})
+
+    async def add_comment(self, comment: Comment) -> Comment:
+        """Add a comment to a Plane issue.
+
+        Args:
+            comment: Comment to add.
+
+        Returns:
+            Created comment with its ID populated.
+
+        Raises:
+            ValueError: If comment creation fails.
+
+        """
+        try:
+            created = await self.client.post(
+                f"/issues/{comment.ticket_id}/comments/",
+                {"comment_html": comment.content},
+            )
+            return map_plane_comment_to_comment(created, comment.ticket_id)
+        except Exception as e:
+            raise ValueError(f"Failed to add comment: {e}") from e
+
+    async def get_comments(
+        self, ticket_id: str, limit: int = 10, offset: int = 0
+    ) -> builtins.list[Comment]:
+        """Get comments for a Plane issue.
+
+        Args:
+            ticket_id: Plane issue UUID.
+            limit: Maximum number of comments to return.
+            offset: Number of comments to skip.
+
+        Returns:
+            List of comments for the issue.
+
+        """
+        try:
+            raw = await self.client.get_paginated(f"/issues/{ticket_id}/comments/")
+            comments = [map_plane_comment_to_comment(c, ticket_id) for c in raw]
+            return comments[offset : offset + limit]
+        except Exception as e:
+            logger.error("Failed to get comments for Plane issue %s: %s", ticket_id, e)
+            return []
+
+    # Hierarchy helpers ------------------------------------------------------
+
+    async def list_tasks_by_issue(self, issue_id: str) -> builtins.list[Task]:
+        """List sub-issues of a Plane issue.
+
+        Args:
+            issue_id: Parent issue UUID.
+
+        Returns:
+            List of sub-issue tasks.
+
+        """
+        try:
+            raw = await self.client.get_paginated(f"/issues/{issue_id}/sub-issues/")
+            states = await self._load_states()
+            return [map_plane_issue_to_task(issue, states) for issue in raw]
+        except Exception as e:
+            logger.error("Failed to list sub-issues for %s: %s", issue_id, e)
+            return []
+
+    async def search_users(self, query: str) -> builtins.list[dict[str, Any]]:
+        """Search workspace members by display name or email.
+
+        Args:
+            query: Search query (name or email).
+
+        Returns:
+            List of user dictionaries with keys: id, name, email.
+
+        """
+        members = await self._load_members()
+        query_lower = query.lower()
+
+        results: builtins.list[dict[str, Any]] = []
+        for member in members:
+            member_obj = member.get("member") or member
+            name = str(member_obj.get("display_name") or "")
+            email = str(member_obj.get("email") or "")
+            if query_lower in name.lower() or query_lower in email.lower():
+                results.append(
+                    {
+                        "id": str(
+                            member.get("member_id") or member_obj.get("id") or ""
+                        ),
+                        "name": name,
+                        "email": email,
+                    }
+                )
+        return results
+
+    # Project (Epic) Operations ---------------------------------------------
+
+    async def project_list(
+        self,
+        scope: ProjectScope | None = None,
+        state: ProjectState | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> builtins.list[Project]:
+        """List Plane projects in the workspace.
+
+        Args:
+            scope: Ignored (Plane projects are workspace-scoped).
+            state: Ignored (Plane projects do not expose universal states).
+            limit: Maximum results.
+            offset: Pagination offset (applied client-side).
+
+        Returns:
+            List of Project objects.
+
+        """
+        try:
+            raw = await self.client.get_paginated("/projects/", workspace_scoped=True)
+        except Exception as e:
+            logger.error("Failed to list Plane projects: %s", e)
+            return []
+
+        projects = [
+            Project(
+                id=str(p.get("id")),
+                platform="plane",
+                platform_id=str(p.get("id")),
+                scope=ProjectScope.TEAM,
+                name=p.get("name", ""),
+                description=p.get("description"),
+            )
+            for p in raw
+            if p.get("id")
+        ]
+        return projects[offset : offset + limit]
+
+    async def project_get(self, project_id: str) -> Project | None:
+        """Get a Plane project by UUID.
+
+        Args:
+            project_id: Plane project UUID.
+
+        Returns:
+            Project object if found, None otherwise.
+
+        """
+        try:
+            p = await self.client.get_workspace(f"/projects/{project_id}/")
+        except Exception as e:
+            logger.error("Failed to get Plane project %s: %s", project_id, e)
+            return None
+
+        if not p.get("id"):
+            return None
+
+        return Project(
+            id=str(p["id"]),
+            platform="plane",
+            platform_id=str(p["id"]),
+            scope=ProjectScope.TEAM,
+            name=p.get("name", ""),
+            description=p.get("description"),
+        )
+
+    async def get_epic(self, epic_id: str) -> Epic | None:
+        """Get a Plane project as an Epic.
+
+        Args:
+            epic_id: Plane project UUID.
+
+        Returns:
+            Epic if found, None otherwise.
+
+        """
+        try:
+            p = await self.client.get_workspace(f"/projects/{epic_id}/")
+            if not p.get("id"):
+                return None
+            return map_plane_project_to_epic(p)
+        except Exception as e:
+            logger.error("Failed to get Plane project %s: %s", epic_id, e)
+            return None
+
+    async def list_issues_by_epic(self, epic_id: str) -> builtins.list[Task]:
+        """List issues belonging to a Plane project (Epic).
+
+        Only the adapter's configured project is queryable via the issue API,
+        so this returns issues when ``epic_id`` matches the configured project.
+
+        Args:
+            epic_id: Plane project UUID.
+
+        Returns:
+            List of issue tasks (empty if ``epic_id`` is a different project).
+
+        """
+        if epic_id != self.project_id:
+            logger.warning(
+                "list_issues_by_epic called for project '%s' but adapter is "
+                "scoped to project '%s'",
+                epic_id,
+                self.project_id,
+            )
+            return []
+        return await self.list(limit=100, filters={"ticket_type": TicketType.ISSUE})
+
+    # Milestone Operations (Plane modules) -----------------------------------
+
+    async def milestone_create(
+        self,
+        name: str,
+        target_date: datetime | None = None,
+        labels: builtins.list[str] | None = None,
+        description: str = "",
+        project_id: str | None = None,
+    ) -> Milestone:
+        """Create a Plane module as a milestone.
+
+        Note: Plane modules group issues by membership, not by labels, so the
+        ``labels`` argument is stored on the returned model's ``labels`` field
+        for reference but is not sent to Plane.
+
+        Args:
+            name: Module name.
+            target_date: Target completion date.
+            labels: Labels (reference only; see note above).
+            description: Module description.
+            project_id: Ignored; the adapter's configured project is used.
+
+        Returns:
+            Created Milestone object.
+
+        Raises:
+            ValueError: If creation fails.
+
+        """
+        payload: dict[str, Any] = {"name": name}
+        if description:
+            payload["description"] = description
+        if target_date:
+            payload["target_date"] = target_date.date().isoformat()
+
+        try:
+            created = await self.client.post("/modules/", payload)
+        except Exception as e:
+            raise ValueError(f"Failed to create Plane module: {e}") from e
+
+        milestone = map_plane_module_to_milestone(created)
+        if labels:
+            milestone.labels = labels
+        return milestone
+
+    async def milestone_get(self, milestone_id: str) -> Milestone | None:
+        """Get a Plane module (milestone) by UUID.
+
+        Args:
+            milestone_id: Module UUID.
+
+        Returns:
+            Milestone with progress, or None if not found.
+
+        """
+        try:
+            module = await self.client.get(f"/modules/{milestone_id}/")
+            if not module.get("id"):
+                return None
+            return map_plane_module_to_milestone(module)
+        except Exception as e:
+            logger.error("Failed to get Plane module %s: %s", milestone_id, e)
+            return None
+
+    async def milestone_list(
+        self,
+        project_id: str | None = None,
+        state: str | None = None,
+    ) -> builtins.list[Milestone]:
+        """List Plane modules (milestones).
+
+        Args:
+            project_id: Ignored; the adapter's configured project is used.
+            state: Optional universal milestone state filter
+                (open/active/completed/closed).
+
+        Returns:
+            List of Milestone objects.
+
+        """
+        try:
+            raw = await self.client.get_paginated("/modules/")
+        except Exception as e:
+            logger.error("Failed to list Plane modules: %s", e)
+            return []
+
+        milestones = [map_plane_module_to_milestone(m) for m in raw]
+        if state:
+            milestones = [m for m in milestones if m.state == state]
+        return milestones
+
+    async def milestone_update(
+        self,
+        milestone_id: str,
+        name: str | None = None,
+        target_date: datetime | None = None,
+        state: str | None = None,
+        labels: builtins.list[str] | None = None,
+        description: str | None = None,
+    ) -> Milestone | None:
+        """Update a Plane module (milestone).
+
+        Args:
+            milestone_id: Module UUID.
+            name: New name.
+            target_date: New target date.
+            state: New universal milestone state (mapped to a Plane module
+                status; unmappable values are ignored).
+            labels: New labels (reference only; not sent to Plane).
+            description: New description.
+
+        Returns:
+            Updated Milestone, or None on failure.
+
+        """
+        payload: dict[str, Any] = {}
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if target_date is not None:
+            payload["target_date"] = target_date.date().isoformat()
+        if state is not None:
+            module_status = _STATE_TO_MODULE_STATUS.get(state.lower())
+            if module_status:
+                payload["status"] = module_status
+
+        try:
+            if payload:
+                await self.client.patch(f"/modules/{milestone_id}/", payload)
+            return await self.milestone_get(milestone_id)
+        except Exception as e:
+            logger.error("Failed to update Plane module %s: %s", milestone_id, e)
+            return None
+
+    async def milestone_delete(self, milestone_id: str) -> bool:
+        """Delete a Plane module (milestone).
+
+        Args:
+            milestone_id: Module UUID.
+
+        Returns:
+            True if deleted, False otherwise.
+
+        """
+        try:
+            await self.client.delete(f"/modules/{milestone_id}/")
+            return True
+        except Exception as e:
+            logger.error("Failed to delete Plane module %s: %s", milestone_id, e)
+            return False
+
+    async def milestone_get_issues(
+        self,
+        milestone_id: str,
+        state: str | None = None,
+    ) -> builtins.list[Task]:
+        """Get issues associated with a Plane module (milestone).
+
+        Args:
+            milestone_id: Module UUID.
+            state: Optional universal issue-state filter.
+
+        Returns:
+            List of issue tasks in the module.
+
+        """
+        try:
+            raw_links = await self.client.get_paginated(
+                f"/modules/{milestone_id}/module-issues/"
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to list issues for Plane module %s: %s", milestone_id, e
+            )
+            return []
+
+        states = await self._load_states()
+        tasks: builtins.list[Task] = []
+        for link in raw_links:
+            # module-issues entries reference an issue by id; the issue payload
+            # may be inlined under "issue_detail" or referenced via "issue".
+            issue = link.get("issue_detail")
+            if issue:
+                tasks.append(map_plane_issue_to_task(issue, states))
+                continue
+
+            issue_id = link.get("issue") or link.get("id")
+            if issue_id:
+                fetched = await self.read(str(issue_id))
+                if fetched:
+                    tasks.append(fetched)
+
+        if state:
+            target = TicketState(state) if isinstance(state, str) else state
+            tasks = [t for t in tasks if t.state == target]
+
+        return tasks
+
+    async def close(self) -> None:
+        """Close the adapter and release HTTP resources."""
+        await self.client.close()
+
+
+# Universal milestone state -> Plane module status.
+_STATE_TO_MODULE_STATUS = {
+    "open": "planned",
+    "active": "in-progress",
+    "completed": "completed",
+    "closed": "cancelled",
+}
+
+
+# Register the adapter
+AdapterRegistry.register("plane", PlaneAdapter)

--- a/src/mcp_ticketer/adapters/plane/client.py
+++ b/src/mcp_ticketer/adapters/plane/client.py
@@ -1,0 +1,443 @@
+"""Plane HTTP client for the REST API v1.
+
+Handles:
+- ``X-API-Key`` header authentication (the key is never logged)
+- Instance-URL validation (https required; cross-host redirects are not
+  followed silently)
+- Rate limiting (429 with Retry-After)
+- Cursor / offset pagination
+- Error handling that never leaks the API key
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INSTANCE_URL = "https://api.plane.so"
+
+
+class PlaneClientError(ValueError):
+    """Raised for Plane API and configuration errors.
+
+    Subclasses ``ValueError`` to match the error-handling convention used by
+    the other adapters in this project.
+    """
+
+
+def normalize_instance_url(instance_url: str | None) -> str:
+    """Validate and normalise a user-supplied Plane instance URL.
+
+    The instance URL is user-controlled, so it is validated to prevent SSRF and
+    credential-leak vectors:
+
+    - The scheme must be ``https`` (an http URL would send the API key in
+      clear text).
+    - A host must be present.
+
+    Args:
+        instance_url: User-supplied instance URL, or None for the default.
+
+    Returns:
+        The normalised base URL with any trailing slash removed.
+
+    Raises:
+        PlaneClientError: If the URL is not a valid https URL.
+
+    """
+    raw = (instance_url or DEFAULT_INSTANCE_URL).strip()
+    parsed = urlparse(raw)
+
+    if parsed.scheme != "https":
+        raise PlaneClientError(
+            f"Plane instance URL must use https (got '{parsed.scheme or 'no scheme'}')"
+        )
+    if not parsed.netloc:
+        raise PlaneClientError("Plane instance URL is missing a host")
+
+    host = (parsed.hostname or "").lower()
+    # Block cloud-metadata + loopback/link-local — never a legitimate remote Plane and a
+    # classic SSRF credential-exfil target (169.254.169.254 etc.). RFC-1918 private IPs are
+    # ALLOWED: a self-hosted Plane on an internal corporate network is a primary use case.
+    if host in {"localhost", "metadata", "instance-data", "metadata.google.internal"}:
+        raise PlaneClientError(f"Plane instance URL host '{host}' is not allowed")
+    blocked = False
+    try:
+        ip = ipaddress.ip_address(host)
+        blocked = (
+            ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified
+        )
+    except ValueError:
+        blocked = False  # hostname literal (incl. internal DNS for self-host) — allowed
+    if blocked:
+        raise PlaneClientError(
+            f"Plane instance URL must not point to a loopback/link-local address (got '{host}')"
+        )
+
+    return raw.rstrip("/")
+
+
+class PlaneClient:
+    """Async HTTP client for the Plane REST API v1.
+
+    The client scopes requests to a single workspace and project. Endpoints
+    passed to the request methods are relative to the project base URL, e.g.
+    ``"/issues/"`` resolves to
+    ``{instance}/api/v1/workspaces/{slug}/projects/{project}/issues/``.
+    Workspace-level endpoints (e.g. members) use ``workspace_path``.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        workspace_slug: str,
+        project_id: str,
+        instance_url: str | None = None,
+        timeout: int = 30,
+        max_retries: int = 3,
+    ):
+        """Initialise the Plane client.
+
+        Args:
+            api_key: Plane personal API key (sent via the ``X-API-Key`` header).
+            workspace_slug: Plane workspace slug.
+            project_id: Plane project UUID.
+            instance_url: Base instance URL (defaults to https://api.plane.so).
+            timeout: Request timeout in seconds.
+            max_retries: Maximum retry attempts for rate limiting / timeouts.
+
+        Raises:
+            PlaneClientError: If the instance URL is invalid.
+
+        """
+        self.api_key = api_key
+        self.workspace_slug = workspace_slug
+        self.project_id = project_id
+        self.instance_url = normalize_instance_url(instance_url)
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+        # Host the API key is bound to. Redirects to any other host are refused
+        # so the key is never replayed to an attacker-controlled origin.
+        self._allowed_host = urlparse(self.instance_url).netloc
+
+        self.headers = {
+            "X-API-Key": api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def api_base(self) -> str:
+        """Base URL for the configured workspace API."""
+        return f"{self.instance_url}/api/v1/workspaces/{self.workspace_slug}"
+
+    @property
+    def project_base(self) -> str:
+        """Base URL for the configured project."""
+        return f"{self.api_base}/projects/{self.project_id}"
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or lazily create the async HTTP client.
+
+        ``follow_redirects`` is disabled: Plane's REST API does not rely on
+        redirects, and following them automatically could replay the API key to
+        a different host.
+
+        Returns:
+            Configured async HTTP client.
+
+        """
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                headers=self.headers,
+                timeout=self.timeout,
+                follow_redirects=False,
+            )
+        return self._client
+
+    async def _handle_rate_limit(self, response: httpx.Response, attempt: int) -> None:
+        """Sleep according to the Retry-After header for a 429 response.
+
+        Args:
+            response: HTTP response with a 429 status.
+            attempt: Current retry attempt number.
+
+        Raises:
+            PlaneClientError: If the maximum retry count is exceeded.
+
+        """
+        if attempt >= self.max_retries:
+            raise PlaneClientError(
+                f"Max retries ({self.max_retries}) exceeded for rate limiting"
+            )
+
+        retry_after = min(int(response.headers.get("Retry-After", 60)), 3600)
+        logger.warning(
+            "Rate limited (429). Waiting %ss before retry %s/%s",
+            retry_after,
+            attempt + 1,
+            self.max_retries,
+        )
+        await asyncio.sleep(retry_after)
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        """Make an HTTP request with retry handling.
+
+        Args:
+            method: HTTP method (GET, POST, PATCH, DELETE).
+            url: Fully-qualified request URL.
+            params: URL query parameters.
+            json: Request body JSON data.
+
+        Returns:
+            Parsed JSON response, or an empty dict for empty (e.g. 204) bodies.
+
+        Raises:
+            PlaneClientError: If the request fails. The error message never
+                contains the API key.
+
+        """
+        client = await self._get_client()
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await client.request(
+                    method=method,
+                    url=url,
+                    params=params,
+                    json=json,
+                )
+
+                if response.status_code == 429:
+                    await self._handle_rate_limit(response, attempt)
+                    continue
+
+                # Refuse redirects to a different host (the API key must never
+                # be sent off-origin). Same-host redirects are also surfaced as
+                # errors rather than followed silently.
+                if response.is_redirect:
+                    location = response.headers.get("location", "")
+                    raise PlaneClientError(
+                        f"Refusing to follow redirect to '{location}' "
+                        f"(expected host '{self._allowed_host}')"
+                    )
+
+                if response.status_code >= 400:
+                    raise PlaneClientError(
+                        f"Plane API error ({response.status_code}): "
+                        f"{self._extract_error(response)}"
+                    )
+
+                if response.status_code == 204 or not response.content:
+                    return {}
+
+                return response.json()
+
+            except httpx.TimeoutException as e:
+                logger.error("Request timeout for %s %s", method, url)
+                if attempt < self.max_retries:
+                    wait_time = 2**attempt
+                    logger.info("Retrying in %ss...", wait_time)
+                    await asyncio.sleep(wait_time)
+                else:
+                    raise PlaneClientError(
+                        f"Request timeout after {self.max_retries} retries"
+                    ) from e
+
+            except httpx.HTTPError as e:
+                # Note: str(e) from httpx contains the URL but never headers,
+                # so the API key is not exposed here.
+                logger.error("HTTP error for %s %s", method, url)
+                raise PlaneClientError(f"HTTP error: {e}") from e
+
+        raise PlaneClientError("Request failed after all retry attempts")
+
+    @staticmethod
+    def _extract_error(response: httpx.Response) -> str:
+        """Extract a human-readable error message from a Plane error response.
+
+        Args:
+            response: HTTP error response.
+
+        Returns:
+            Best-effort error detail string.
+
+        """
+        try:
+            payload = response.json()
+        except Exception:
+            # Never return the raw body — it can echo request details. Use status only.
+            return response.reason_phrase or f"HTTP {response.status_code}"
+
+        if isinstance(payload, dict):
+            for key in ("error", "detail", "message"):
+                if payload.get(key):
+                    return str(payload[key])
+        return str(payload)
+
+    # Project-scoped helpers -------------------------------------------------
+
+    async def get(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
+        """GET a project-scoped endpoint.
+
+        Args:
+            endpoint: Endpoint relative to the project base (e.g. "/issues/").
+            params: Query parameters.
+
+        Returns:
+            Parsed JSON response.
+
+        """
+        return await self._request(
+            "GET", f"{self.project_base}{endpoint}", params=params
+        )
+
+    async def post(self, endpoint: str, data: dict[str, Any]) -> Any:
+        """POST to a project-scoped endpoint.
+
+        Args:
+            endpoint: Endpoint relative to the project base.
+            data: Request body data.
+
+        Returns:
+            Parsed JSON response.
+
+        """
+        return await self._request("POST", f"{self.project_base}{endpoint}", json=data)
+
+    async def patch(self, endpoint: str, data: dict[str, Any]) -> Any:
+        """PATCH a project-scoped endpoint.
+
+        Args:
+            endpoint: Endpoint relative to the project base.
+            data: Request body data.
+
+        Returns:
+            Parsed JSON response.
+
+        """
+        return await self._request("PATCH", f"{self.project_base}{endpoint}", json=data)
+
+    async def delete(self, endpoint: str) -> Any:
+        """DELETE a project-scoped endpoint.
+
+        Args:
+            endpoint: Endpoint relative to the project base.
+
+        Returns:
+            Parsed JSON response (usually empty).
+
+        """
+        return await self._request("DELETE", f"{self.project_base}{endpoint}")
+
+    # Workspace-scoped helper ------------------------------------------------
+
+    async def get_workspace(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> Any:
+        """GET a workspace-scoped endpoint (e.g. "/members/").
+
+        Args:
+            endpoint: Endpoint relative to the workspace base.
+            params: Query parameters.
+
+        Returns:
+            Parsed JSON response.
+
+        """
+        return await self._request("GET", f"{self.api_base}{endpoint}", params=params)
+
+    # Pagination -------------------------------------------------------------
+
+    async def get_paginated(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        workspace_scoped: bool = False,
+        per_page: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Fetch all pages from a paginated Plane list endpoint.
+
+        Plane list responses are either a bare list or a paginated envelope of
+        the form ``{"results": [...], "next_cursor": ..., "next_page_results":
+        bool}``. This helper handles both.
+
+        Args:
+            endpoint: Endpoint to fetch.
+            params: Base query parameters.
+            workspace_scoped: If True, resolve against the workspace base
+                instead of the project base.
+            per_page: Items per page.
+
+        Returns:
+            Flattened list of all result items.
+
+        """
+        base_params = dict(params or {})
+        base_params.setdefault("per_page", per_page)
+
+        getter = self.get_workspace if workspace_scoped else self.get
+
+        all_results: list[dict[str, Any]] = []
+        cursor: str | None = None
+
+        while True:
+            page_params = dict(base_params)
+            if cursor:
+                page_params["cursor"] = cursor
+
+            response = await getter(endpoint, params=page_params)
+
+            if isinstance(response, list):
+                all_results.extend(response)
+                break
+
+            if isinstance(response, dict):
+                results = response.get("results", [])
+                all_results.extend(results)
+
+                if not response.get("next_page_results"):
+                    break
+                cursor = response.get("next_cursor")
+                if not cursor:
+                    break
+            else:
+                break
+
+        return all_results
+
+    async def test_connection(self) -> bool:
+        """Verify the credentials and configuration by listing states.
+
+        Returns:
+            True if the project states endpoint responds successfully.
+
+        """
+        try:
+            await self.get("/states/")
+            return True
+        except Exception:
+            logger.error("Plane connection test failed")
+            return False
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None

--- a/src/mcp_ticketer/adapters/plane/mappers.py
+++ b/src/mcp_ticketer/adapters/plane/mappers.py
@@ -1,0 +1,304 @@
+"""Data mappers for converting between Plane and mcp-ticketer models."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from ...core.models import (
+    Comment,
+    Epic,
+    Milestone,
+    Task,
+    TicketState,
+    TicketType,
+)
+from .types import (
+    GROUP_TO_STATE,
+    PlaneStateGroup,
+    map_priority_from_plane,
+    refine_state_from_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def parse_plane_datetime(date_str: str | None) -> datetime | None:
+    """Parse a Plane datetime / date string into a datetime.
+
+    Plane returns ISO 8601 timestamps (e.g. "2024-11-15T10:30:00.000000Z") and
+    plain dates (e.g. "2024-11-15") for ``target_date``.
+
+    Args:
+        date_str: ISO 8601 datetime/date string, or None.
+
+    Returns:
+        Parsed datetime, or None on failure.
+
+    """
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        logger.warning("Failed to parse Plane datetime '%s'", date_str)
+        return None
+
+
+def map_plane_issue_to_task(
+    issue: dict[str, Any],
+    state_by_id: dict[str, dict[str, Any]] | None = None,
+) -> Task:
+    """Map a Plane issue payload to a universal Task.
+
+    The ticket type is derived from the presence of a parent: an issue with a
+    ``parent`` is a sub-issue (TASK), otherwise it is a standard ISSUE.
+
+    Args:
+        issue: Plane issue payload.
+        state_by_id: Optional mapping of state UUID -> state record, used to
+            resolve the issue's universal state from its state group and name.
+
+    Returns:
+        Task model instance.
+
+    """
+    parent_id = issue.get("parent")
+    ticket_type = TicketType.TASK if parent_id else TicketType.ISSUE
+
+    state = _resolve_issue_state(issue, state_by_id)
+    priority = map_priority_from_plane(issue.get("priority"))
+
+    assignees = issue.get("assignees") or []
+    assignee = assignees[0] if assignees else None
+
+    labels = issue.get("labels") or []
+
+    return Task(
+        id=issue.get("id"),
+        title=issue.get("name", ""),
+        description=issue.get("description_html") or issue.get("description_stripped"),
+        state=state,
+        priority=priority,
+        tags=[str(label) for label in labels],
+        assignee=assignee,
+        ticket_type=ticket_type,
+        parent_issue=parent_id if ticket_type == TicketType.TASK else None,
+        parent_epic=issue.get("project") if ticket_type == TicketType.ISSUE else None,
+        milestone_id=issue.get("module"),
+        created_at=parse_plane_datetime(issue.get("created_at")),
+        updated_at=parse_plane_datetime(issue.get("updated_at")),
+        metadata={
+            "plane_id": issue.get("id"),
+            "plane_sequence_id": issue.get("sequence_id"),
+            "plane_project": issue.get("project"),
+            "plane_workspace": issue.get("workspace"),
+            "plane_state_id": issue.get("state"),
+            "plane_priority": issue.get("priority"),
+            "plane_target_date": issue.get("target_date"),
+            "plane_assignees": assignees,
+            "plane_labels": labels,
+            "plane_parent": parent_id,
+        },
+    )
+
+
+def _resolve_issue_state(
+    issue: dict[str, Any],
+    state_by_id: dict[str, dict[str, Any]] | None,
+) -> TicketState:
+    """Resolve an issue's universal state from its Plane state record.
+
+    Args:
+        issue: Plane issue payload.
+        state_by_id: Optional mapping of state UUID -> state record.
+
+    Returns:
+        Universal ticket state (defaults to OPEN when unknown).
+
+    """
+    state_id = issue.get("state")
+    if not state_id or not state_by_id:
+        return TicketState.OPEN
+
+    state_record = state_by_id.get(state_id)
+    if not state_record:
+        return TicketState.OPEN
+
+    group = state_record.get("group", "")
+    name = state_record.get("name")
+
+    try:
+        base_state = GROUP_TO_STATE[PlaneStateGroup(group)]
+    except ValueError:
+        return TicketState.OPEN
+
+    return refine_state_from_name(base_state, name)
+
+
+def map_task_to_plane_issue(
+    task: Task,
+    state_id: str | None = None,
+    assignee_ids: list[str] | None = None,
+    label_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a Plane issue create/update payload from a Task.
+
+    Args:
+        task: Task model instance.
+        state_id: Resolved Plane state UUID (optional).
+        assignee_ids: Resolved Plane assignee UUIDs (optional).
+        label_ids: Resolved Plane label UUIDs (optional).
+
+    Returns:
+        Plane issue payload for create/update.
+
+    """
+    from .types import map_priority_to_plane
+
+    payload: dict[str, Any] = {"name": task.title}
+
+    if task.description is not None:
+        payload["description_html"] = task.description
+
+    payload["priority"] = map_priority_to_plane(task.priority)
+
+    if state_id:
+        payload["state"] = state_id
+
+    if assignee_ids is not None:
+        payload["assignees"] = assignee_ids
+
+    if label_ids is not None:
+        payload["labels"] = label_ids
+
+    if task.parent_issue:
+        payload["parent"] = task.parent_issue
+
+    target_date = task.metadata.get("plane_target_date")
+    if target_date:
+        payload["target_date"] = target_date
+
+    return payload
+
+
+def map_plane_comment_to_comment(comment: dict[str, Any], issue_id: str) -> Comment:
+    """Map a Plane issue comment to a universal Comment.
+
+    Args:
+        comment: Plane comment payload.
+        issue_id: Parent issue UUID.
+
+    Returns:
+        Comment model instance.
+
+    """
+    return Comment(
+        id=comment.get("id"),
+        ticket_id=issue_id,
+        author=comment.get("actor") or comment.get("created_by"),
+        content=comment.get("comment_html") or comment.get("comment_stripped") or "",
+        created_at=parse_plane_datetime(comment.get("created_at")),
+        metadata={
+            "plane_id": comment.get("id"),
+            "plane_actor": comment.get("actor"),
+            "plane_created_by": comment.get("created_by"),
+        },
+    )
+
+
+def map_plane_module_to_milestone(module: dict[str, Any]) -> Milestone:
+    """Map a Plane module to a universal Milestone.
+
+    Plane modules are the closest native concept to a milestone: a named
+    grouping of issues with optional start/target dates and a status.
+
+    Args:
+        module: Plane module payload.
+
+    Returns:
+        Milestone model instance.
+
+    """
+    total = module.get("total_issues")
+    completed = module.get("completed_issues")
+    progress = 0.0
+    if isinstance(total, int) and total > 0 and isinstance(completed, int):
+        progress = round((completed / total) * 100.0, 1)
+
+    return Milestone(
+        id=module.get("id"),
+        name=module.get("name", ""),
+        target_date=parse_plane_datetime(module.get("target_date")),
+        state=_map_module_status(module.get("status")),
+        description=module.get("description") or "",
+        total_issues=total if isinstance(total, int) else 0,
+        closed_issues=completed if isinstance(completed, int) else 0,
+        progress_pct=progress,
+        project_id=module.get("project"),
+        created_at=parse_plane_datetime(module.get("created_at")),
+        updated_at=parse_plane_datetime(module.get("updated_at")),
+        platform_data={
+            "plane_id": module.get("id"),
+            "plane_status": module.get("status"),
+            "plane_start_date": module.get("start_date"),
+            "plane_target_date": module.get("target_date"),
+            "plane_project": module.get("project"),
+            "plane_workspace": module.get("workspace"),
+        },
+    )
+
+
+# Plane module status -> universal milestone state.
+_MODULE_STATUS_TO_STATE = {
+    "backlog": "open",
+    "planned": "open",
+    "in-progress": "active",
+    "paused": "active",
+    "completed": "completed",
+    "cancelled": "closed",
+}
+
+
+def _map_module_status(status: str | None) -> str:
+    """Map a Plane module status to a universal milestone state.
+
+    Args:
+        status: Plane module status string.
+
+    Returns:
+        Universal milestone state (open/active/completed/closed).
+
+    """
+    if not status:
+        return "open"
+    return _MODULE_STATUS_TO_STATE.get(status.lower(), "open")
+
+
+def map_plane_project_to_epic(project: dict[str, Any]) -> Epic:
+    """Map a Plane project payload to an Epic.
+
+    Plane projects are the top-level container, so they map to the universal
+    Epic concept (used by ``project_list`` / ``get_epic``).
+
+    Args:
+        project: Plane project payload.
+
+    Returns:
+        Epic model instance.
+
+    """
+    return Epic(
+        id=project.get("id"),
+        title=project.get("name", ""),
+        description=project.get("description"),
+        state=TicketState.OPEN,
+        created_at=parse_plane_datetime(project.get("created_at")),
+        updated_at=parse_plane_datetime(project.get("updated_at")),
+        metadata={
+            "plane_id": project.get("id"),
+            "plane_identifier": project.get("identifier"),
+            "plane_workspace": project.get("workspace"),
+        },
+    )

--- a/src/mcp_ticketer/adapters/plane/types.py
+++ b/src/mcp_ticketer/adapters/plane/types.py
@@ -1,0 +1,165 @@
+"""Plane-specific types, constants, and state mappings.
+
+Plane organises issue states into *state groups* (backlog, unstarted, started,
+completed, cancelled) with one or more named states per group, configured
+per-project. Unlike Asana (a simple completed boolean), Plane has real
+workflow states, so the mapping here resolves a universal ``TicketState`` to a
+concrete state UUID by matching first on the state *name* and then falling back
+to the state *group*.
+"""
+
+from enum import Enum
+
+from ...core.models import Priority, TicketState
+
+
+class PlaneStateGroup(str, Enum):
+    """Plane state groups.
+
+    Every Plane state belongs to exactly one of these groups. The group is the
+    most reliable signal for mapping to a universal ``TicketState`` because the
+    per-project state *names* are user-defined and free-form.
+    """
+
+    BACKLOG = "backlog"
+    UNSTARTED = "unstarted"
+    STARTED = "started"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class PlanePriority(str, Enum):
+    """Plane priority values (native API enum)."""
+
+    URGENT = "urgent"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    NONE = "none"
+
+
+# Universal TicketState -> Plane state group.
+#
+# This is the coarse mapping used to choose a target state when transitioning.
+# The adapter refines the choice by also matching on the state name (see
+# ``resolve_state_id`` in the adapter) so richer universal states such as
+# READY / TESTED / WAITING / BLOCKED land on an appropriately named state when
+# the project defines one.
+STATE_TO_GROUP: dict[TicketState, PlaneStateGroup] = {
+    TicketState.OPEN: PlaneStateGroup.UNSTARTED,
+    TicketState.IN_PROGRESS: PlaneStateGroup.STARTED,
+    TicketState.READY: PlaneStateGroup.STARTED,
+    TicketState.TESTED: PlaneStateGroup.STARTED,
+    TicketState.DONE: PlaneStateGroup.COMPLETED,
+    TicketState.WAITING: PlaneStateGroup.STARTED,
+    TicketState.BLOCKED: PlaneStateGroup.STARTED,
+    TicketState.CLOSED: PlaneStateGroup.CANCELLED,
+}
+
+
+# Plane state group -> universal TicketState.
+#
+# Used when reading an issue back. Group is authoritative; the adapter applies
+# name-based refinement on top of this for fine-grained states.
+GROUP_TO_STATE: dict[PlaneStateGroup, TicketState] = {
+    PlaneStateGroup.BACKLOG: TicketState.OPEN,
+    PlaneStateGroup.UNSTARTED: TicketState.OPEN,
+    PlaneStateGroup.STARTED: TicketState.IN_PROGRESS,
+    PlaneStateGroup.COMPLETED: TicketState.DONE,
+    PlaneStateGroup.CANCELLED: TicketState.CLOSED,
+}
+
+
+# Keyword hints used to refine a universal state from a Plane state *name*.
+# Order matters: the first universal state whose keywords match the (lowercased)
+# state name wins. Only states that are otherwise indistinguishable by group
+# are listed here; DONE/CLOSED/OPEN are handled by the group mapping.
+STATE_NAME_KEYWORDS: list[tuple[TicketState, tuple[str, ...]]] = [
+    (TicketState.BLOCKED, ("blocked", "stuck", "impediment")),
+    (TicketState.WAITING, ("waiting", "on hold", "hold", "paused")),
+    (TicketState.TESTED, ("tested", "qa", "verified", "verify")),
+    (TicketState.READY, ("ready", "review", "in review")),
+    (TicketState.IN_PROGRESS, ("progress", "started", "doing", "active")),
+]
+
+
+# Universal Priority -> Plane priority.
+TO_PLANE_PRIORITY: dict[Priority, str] = {
+    Priority.LOW: PlanePriority.LOW.value,
+    Priority.MEDIUM: PlanePriority.MEDIUM.value,
+    Priority.HIGH: PlanePriority.HIGH.value,
+    Priority.CRITICAL: PlanePriority.URGENT.value,
+}
+
+
+# Plane priority -> universal Priority.
+FROM_PLANE_PRIORITY: dict[str, Priority] = {
+    PlanePriority.URGENT.value: Priority.CRITICAL,
+    PlanePriority.HIGH.value: Priority.HIGH,
+    PlanePriority.MEDIUM.value: Priority.MEDIUM,
+    PlanePriority.LOW.value: Priority.LOW,
+    PlanePriority.NONE.value: Priority.MEDIUM,
+}
+
+
+def map_priority_to_plane(priority: Priority) -> str:
+    """Map universal priority to a Plane priority value.
+
+    Args:
+        priority: Universal priority level.
+
+    Returns:
+        Plane priority string (one of urgent/high/medium/low/none).
+
+    """
+    return TO_PLANE_PRIORITY.get(priority, PlanePriority.MEDIUM.value)
+
+
+def map_priority_from_plane(plane_priority: str | None) -> Priority:
+    """Map a Plane priority value to a universal priority.
+
+    Args:
+        plane_priority: Plane priority string (may be None).
+
+    Returns:
+        Universal priority level.
+
+    """
+    if not plane_priority:
+        return Priority.MEDIUM
+    return FROM_PLANE_PRIORITY.get(plane_priority.lower(), Priority.MEDIUM)
+
+
+def refine_state_from_name(
+    group_state: TicketState, state_name: str | None
+) -> TicketState:
+    """Refine a group-derived state using the Plane state name.
+
+    The state *group* gives a coarse state (e.g. STARTED -> IN_PROGRESS). When
+    the project defines more granular states (e.g. a "Blocked" or "Ready for
+    review" state, both in the ``started`` group), the name lets us recover the
+    richer universal state.
+
+    Completed and cancelled groups are never refined: a completed state always
+    maps to DONE and a cancelled state always maps to CLOSED.
+
+    Args:
+        group_state: Universal state derived from the Plane state group.
+        state_name: The Plane state name (may be None).
+
+    Returns:
+        The refined universal ticket state.
+
+    """
+    if group_state in (TicketState.DONE, TicketState.CLOSED):
+        return group_state
+
+    if not state_name:
+        return group_state
+
+    name_lower = state_name.lower()
+    for state, keywords in STATE_NAME_KEYWORDS:
+        if any(keyword in name_lower for keyword in keywords):
+            return state
+
+    return group_state

--- a/src/mcp_ticketer/core/env_discovery.py
+++ b/src/mcp_ticketer/core/env_discovery.py
@@ -103,6 +103,32 @@ AITRACKDOWN_PATH_PATTERNS = [
     "MCP_TICKETER_AITRACKDOWN_BASE_PATH",
 ]
 
+PLANE_KEY_PATTERNS = [
+    "PLANE_API_KEY",
+    "PLANE_TOKEN",
+    "PLANE_KEY",
+    "MCP_TICKETER_PLANE_API_KEY",
+]
+
+PLANE_INSTANCE_PATTERNS = [
+    "PLANE_INSTANCE_URL",
+    "PLANE_URL",
+    "PLANE_HOST",
+    "MCP_TICKETER_PLANE_INSTANCE_URL",
+]
+
+PLANE_WORKSPACE_PATTERNS = [
+    "PLANE_WORKSPACE_SLUG",
+    "PLANE_WORKSPACE",
+    "MCP_TICKETER_PLANE_WORKSPACE_SLUG",
+]
+
+PLANE_PROJECT_PATTERNS = [
+    "PLANE_PROJECT_ID",
+    "PLANE_PROJECT",
+    "MCP_TICKETER_PLANE_PROJECT_ID",
+]
+
 
 @dataclass
 class DiscoveredAdapter:
@@ -213,6 +239,12 @@ class EnvDiscovery:
         )
         if jira_adapter:
             result.adapters.append(jira_adapter)
+
+        plane_adapter = self._detect_plane(
+            env_vars, result.env_files_found[0] if result.env_files_found else ".env"
+        )
+        if plane_adapter:
+            result.adapters.append(plane_adapter)
 
         aitrackdown_adapter = self._detect_aitrackdown(
             env_vars, result.env_files_found[0] if result.env_files_found else ".env"
@@ -470,6 +502,62 @@ class EnvDiscovery:
             found_in=found_in,
         )
 
+    def _detect_plane(
+        self, env_vars: dict[str, str], found_in: str
+    ) -> DiscoveredAdapter | None:
+        """Detect Plane adapter configuration.
+
+        Args:
+            env_vars: Environment variables
+            found_in: Which file the config was found in
+
+        Returns:
+            DiscoveredAdapter if Plane config detected, None otherwise
+
+        """
+        api_key = self._find_key_value(env_vars, PLANE_KEY_PATTERNS)
+
+        if not api_key:
+            return None
+
+        config: dict[str, Any] = {
+            "api_key": api_key,
+            "adapter": "plane",
+        }
+
+        missing_fields: list[str] = []
+        confidence = 0.4  # Has API key
+
+        # Instance URL (optional - defaults to https://api.plane.so)
+        instance_url = self._find_key_value(env_vars, PLANE_INSTANCE_PATTERNS)
+        if instance_url:
+            config["instance_url"] = instance_url
+            confidence += 0.1
+
+        # Workspace slug (required)
+        workspace_slug = self._find_key_value(env_vars, PLANE_WORKSPACE_PATTERNS)
+        if workspace_slug:
+            config["workspace_slug"] = workspace_slug
+            confidence += 0.25
+        else:
+            missing_fields.append("workspace_slug")
+
+        # Project ID (required)
+        project_id = self._find_key_value(env_vars, PLANE_PROJECT_PATTERNS)
+        if project_id:
+            config["project_id"] = project_id
+            confidence += 0.25
+        else:
+            missing_fields.append("project_id")
+
+        return DiscoveredAdapter(
+            adapter_type="plane",
+            config=config,
+            confidence=min(confidence, 1.0),
+            missing_fields=missing_fields,
+            found_in=found_in,
+        )
+
     def _detect_aitrackdown(
         self, env_vars: dict[str, str], found_in: str
     ) -> DiscoveredAdapter | None:
@@ -501,6 +589,7 @@ class EnvDiscovery:
             any(key.startswith("LINEAR_") for key in env_vars)
             or any(key.startswith("GITHUB_") for key in env_vars)
             or any(key.startswith("JIRA_") for key in env_vars)
+            or any(key.startswith("PLANE_") for key in env_vars)
         )
 
         if not base_path and not aitrackdown_dir.exists():

--- a/tests/adapters/test_plane.py
+++ b/tests/adapters/test_plane.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Unit tests for the Plane adapter (mocked HTTP only).
+
+Modeled on the JIRA/Linear adapter tests: the adapter's HTTP ``client`` is
+replaced with an ``AsyncMock`` so no real network calls are made.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_ticketer.adapters.plane import PlaneAdapter
+from mcp_ticketer.adapters.plane.client import (
+    PlaneClient,
+    PlaneClientError,
+    normalize_instance_url,
+)
+from mcp_ticketer.adapters.plane.types import (
+    map_priority_from_plane,
+    map_priority_to_plane,
+    refine_state_from_name,
+)
+from mcp_ticketer.core.models import (
+    Comment,
+    Priority,
+    SearchQuery,
+    Task,
+    TicketState,
+    TicketType,
+)
+from mcp_ticketer.core.registry import AdapterRegistry
+
+# Plane state records keyed as the API returns them.
+SAMPLE_STATES = [
+    {"id": "state-backlog", "name": "Backlog", "group": "backlog", "default": True},
+    {"id": "state-todo", "name": "Todo", "group": "unstarted", "default": False},
+    {"id": "state-prog", "name": "In Progress", "group": "started", "default": True},
+    {"id": "state-blocked", "name": "Blocked", "group": "started", "default": False},
+    {"id": "state-done", "name": "Done", "group": "completed", "default": True},
+    {"id": "state-cancel", "name": "Cancelled", "group": "cancelled", "default": True},
+]
+
+SAMPLE_ISSUE = {
+    "id": "issue-1",
+    "name": "Fix login bug",
+    "description_html": "<p>SSO broken</p>",
+    "priority": "high",
+    "state": "state-prog",
+    "assignees": ["user-1"],
+    "labels": ["label-1"],
+    "project": "proj-1",
+    "workspace": "ws-1",
+    "parent": None,
+    "sequence_id": 42,
+    "created_at": "2024-11-15T10:30:00.000000Z",
+    "updated_at": "2024-11-16T10:30:00.000000Z",
+}
+
+
+@pytest.fixture
+def plane_config():
+    """Valid Plane configuration for testing."""
+    return {
+        "api_key": "plane_api_test_key_1234567890",
+        "instance_url": "https://plane.example.com",
+        "workspace_slug": "test-workspace",
+        "project_id": "proj-1",
+    }
+
+
+@pytest.fixture
+def plane_adapter(plane_config):
+    """Create a PlaneAdapter with its HTTP client mocked out."""
+    adapter = PlaneAdapter(plane_config)
+
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock()
+    mock_client.post = AsyncMock()
+    mock_client.patch = AsyncMock()
+    mock_client.delete = AsyncMock()
+    mock_client.get_workspace = AsyncMock()
+    mock_client.get_paginated = AsyncMock()
+    mock_client.test_connection = AsyncMock(return_value=True)
+    mock_client.close = AsyncMock()
+    adapter.client = mock_client
+
+    # Pre-warm the state cache so state resolution does not hit the client.
+    adapter._states_by_id = {s["id"]: s for s in SAMPLE_STATES}
+    adapter._states_loaded = True
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Configuration & security
+# ---------------------------------------------------------------------------
+
+
+class TestPlaneClientSecurity:
+    """Instance-URL validation and credential-handling tests."""
+
+    def test_normalize_instance_url_defaults_to_cloud(self):
+        """A missing instance URL falls back to the cloud default."""
+        assert normalize_instance_url(None) == "https://api.plane.so"
+
+    def test_normalize_instance_url_strips_trailing_slash(self):
+        """Trailing slashes are stripped from the instance URL."""
+        assert (
+            normalize_instance_url("https://plane.example.com/")
+            == "https://plane.example.com"
+        )
+
+    def test_normalize_instance_url_rejects_http(self):
+        """An http:// instance URL is rejected (key would leak in clear text)."""
+        with pytest.raises(PlaneClientError, match="must use https"):
+            normalize_instance_url("http://plane.example.com")
+
+    def test_normalize_instance_url_rejects_missing_host(self):
+        """A URL with no host is rejected."""
+        with pytest.raises(PlaneClientError, match="missing a host"):
+            normalize_instance_url("https://")
+
+    def test_api_key_in_header_not_url(self):
+        """The API key is sent via the X-API-Key header, not the URL."""
+        client = PlaneClient(
+            api_key="secret-key",
+            workspace_slug="ws",
+            project_id="proj",
+            instance_url="https://plane.example.com",
+        )
+        assert client.headers["X-API-Key"] == "secret-key"
+        assert "secret-key" not in client.project_base
+
+    def test_client_constructor_rejects_http_instance(self):
+        """Constructing a client with an http instance URL raises."""
+        with pytest.raises(PlaneClientError, match="must use https"):
+            PlaneClient(
+                api_key="k",
+                workspace_slug="ws",
+                project_id="proj",
+                instance_url="http://insecure.example.com",
+            )
+
+    def test_project_base_url_shape(self):
+        """The project base URL follows the documented Plane path shape."""
+        client = PlaneClient(
+            api_key="k",
+            workspace_slug="ws",
+            project_id="proj",
+            instance_url="https://plane.example.com",
+        )
+        assert client.project_base == (
+            "https://plane.example.com/api/v1/workspaces/ws/projects/proj"
+        )
+
+
+class TestPlaneConfig:
+    """Adapter configuration validation."""
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        """A missing API key raises ValueError."""
+        monkeypatch.delenv("PLANE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="Plane API key is required"):
+            PlaneAdapter({"workspace_slug": "ws", "project_id": "p"})
+
+    def test_missing_workspace_raises(self, monkeypatch):
+        """A missing workspace slug raises ValueError."""
+        monkeypatch.delenv("PLANE_WORKSPACE_SLUG", raising=False)
+        with pytest.raises(ValueError, match="workspace slug is required"):
+            PlaneAdapter({"api_key": "k", "project_id": "p"})
+
+    def test_missing_project_raises(self, monkeypatch):
+        """A missing project ID raises ValueError."""
+        monkeypatch.delenv("PLANE_PROJECT_ID", raising=False)
+        with pytest.raises(ValueError, match="project ID is required"):
+            PlaneAdapter({"api_key": "k", "workspace_slug": "ws"})
+
+    def test_validate_credentials_ok(self, plane_adapter):
+        """validate_credentials returns True for a complete config."""
+        ok, msg = plane_adapter.validate_credentials()
+        assert ok is True
+        assert msg == ""
+
+    def test_config_from_env(self, monkeypatch):
+        """Config falls back to environment variables."""
+        monkeypatch.setenv("PLANE_API_KEY", "env-key")
+        monkeypatch.setenv("PLANE_WORKSPACE_SLUG", "env-ws")
+        monkeypatch.setenv("PLANE_PROJECT_ID", "env-proj")
+        adapter = PlaneAdapter({})
+        assert adapter.api_key == "env-key"
+        assert adapter.workspace_slug == "env-ws"
+        assert adapter.project_id == "env-proj"
+
+
+# ---------------------------------------------------------------------------
+# State & priority mapping
+# ---------------------------------------------------------------------------
+
+
+class TestStateAndPriorityMapping:
+    """Pure mapping helpers and state resolution."""
+
+    def test_state_mapping_to_groups(self, plane_adapter):
+        """_get_state_mapping returns universal states keyed to Plane groups."""
+        mapping = plane_adapter._get_state_mapping()
+        assert mapping[TicketState.OPEN] == "unstarted"
+        assert mapping[TicketState.IN_PROGRESS] == "started"
+        assert mapping[TicketState.DONE] == "completed"
+        assert mapping[TicketState.CLOSED] == "cancelled"
+
+    def test_available_states(self, plane_adapter):
+        """get_available_states exposes the Plane group names."""
+        states = plane_adapter.get_available_states()
+        assert set(states) == {
+            "backlog",
+            "unstarted",
+            "started",
+            "completed",
+            "cancelled",
+        }
+
+    def test_priority_to_plane(self):
+        """Universal priority maps to Plane priority (CRITICAL -> urgent)."""
+        assert map_priority_to_plane(Priority.CRITICAL) == "urgent"
+        assert map_priority_to_plane(Priority.HIGH) == "high"
+        assert map_priority_to_plane(Priority.LOW) == "low"
+
+    def test_priority_from_plane(self):
+        """Plane priority maps back to universal priority."""
+        assert map_priority_from_plane("urgent") == Priority.CRITICAL
+        assert map_priority_from_plane("none") == Priority.MEDIUM
+        assert map_priority_from_plane(None) == Priority.MEDIUM
+
+    def test_refine_state_keeps_completed(self):
+        """Completed states are never refined away from DONE."""
+        assert refine_state_from_name(TicketState.DONE, "Anything") == TicketState.DONE
+
+    def test_refine_state_detects_blocked(self):
+        """A 'Blocked' started-group name refines to BLOCKED."""
+        assert (
+            refine_state_from_name(TicketState.IN_PROGRESS, "Blocked")
+            == TicketState.BLOCKED
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_state_id_prefers_named_state(self, plane_adapter):
+        """BLOCKED resolves to the project's 'Blocked' state, not the default."""
+        state_id = await plane_adapter.resolve_state_id(TicketState.BLOCKED)
+        assert state_id == "state-blocked"
+
+    @pytest.mark.asyncio
+    async def test_resolve_state_id_falls_back_to_default(self, plane_adapter):
+        """IN_PROGRESS with no name match falls back to the group default."""
+        state_id = await plane_adapter.resolve_state_id(TicketState.IN_PROGRESS)
+        assert state_id == "state-prog"
+
+    @pytest.mark.asyncio
+    async def test_resolve_state_id_done(self, plane_adapter):
+        """DONE resolves to a completed-group state."""
+        state_id = await plane_adapter.resolve_state_id(TicketState.DONE)
+        assert state_id == "state-done"
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCrud:
+    """Create / read / update / delete / list / search."""
+
+    @pytest.mark.asyncio
+    async def test_create_issue(self, plane_adapter):
+        """create() posts an issue payload and maps the result back."""
+        plane_adapter.client.get_paginated.return_value = []  # labels lookup
+        plane_adapter.client.post.return_value = SAMPLE_ISSUE
+
+        task = Task(
+            title="Fix login bug",
+            ticket_type=TicketType.ISSUE,
+            state=TicketState.IN_PROGRESS,
+        )
+        result = await plane_adapter.create(task)
+
+        assert result.id == "issue-1"
+        assert result.title == "Fix login bug"
+        assert result.priority == Priority.HIGH
+        assert result.state == TicketState.IN_PROGRESS
+        # Payload posted to the issues endpoint with the resolved state
+        # (IN_PROGRESS -> the project's default 'started' state).
+        plane_adapter.client.post.assert_awaited()
+        endpoint, payload = plane_adapter.client.post.await_args.args
+        assert endpoint == "/issues/"
+        assert payload["name"] == "Fix login bug"
+        assert payload["state"] == "state-prog"
+
+    @pytest.mark.asyncio
+    async def test_read_issue(self, plane_adapter):
+        """read() fetches and maps an issue, with name-refined state."""
+        plane_adapter.client.get.return_value = SAMPLE_ISSUE
+        result = await plane_adapter.read("issue-1")
+
+        assert result is not None
+        assert result.id == "issue-1"
+        assert result.state == TicketState.IN_PROGRESS
+        assert result.metadata["plane_sequence_id"] == 42
+        plane_adapter.client.get.assert_awaited_with("/issues/issue-1/")
+
+    @pytest.mark.asyncio
+    async def test_read_subissue_is_task_type(self, plane_adapter):
+        """An issue with a parent maps to TASK type."""
+        sub = dict(SAMPLE_ISSUE, id="issue-2", parent="issue-1")
+        plane_adapter.client.get.return_value = sub
+        result = await plane_adapter.read("issue-2")
+
+        assert result is not None
+        assert result.ticket_type == TicketType.TASK
+        assert result.parent_issue == "issue-1"
+
+    @pytest.mark.asyncio
+    async def test_read_missing_returns_none(self, plane_adapter):
+        """A client error during read returns None, not an exception."""
+        plane_adapter.client.get.side_effect = PlaneClientError("404")
+        assert await plane_adapter.read("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_update_issue(self, plane_adapter):
+        """update() patches mapped fields and re-reads the issue."""
+        updated = dict(SAMPLE_ISSUE, name="Renamed", state="state-done")
+        plane_adapter.client.patch.return_value = {}
+        plane_adapter.client.get.return_value = updated
+
+        result = await plane_adapter.update(
+            "issue-1", {"title": "Renamed", "state": TicketState.DONE}
+        )
+
+        assert result is not None
+        assert result.title == "Renamed"
+        assert result.state == TicketState.DONE
+        patch_endpoint, patch_payload = plane_adapter.client.patch.await_args.args
+        assert patch_endpoint == "/issues/issue-1/"
+        assert patch_payload["name"] == "Renamed"
+        assert patch_payload["state"] == "state-done"
+
+    @pytest.mark.asyncio
+    async def test_transition_state(self, plane_adapter):
+        """transition_state() delegates to update with a resolved state."""
+        plane_adapter.client.patch.return_value = {}
+        plane_adapter.client.get.return_value = dict(SAMPLE_ISSUE, state="state-cancel")
+
+        result = await plane_adapter.transition_state("issue-1", TicketState.CLOSED)
+        assert result is not None
+        assert result.state == TicketState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_delete_issue(self, plane_adapter):
+        """delete() returns True on success."""
+        plane_adapter.client.delete.return_value = {}
+        assert await plane_adapter.delete("issue-1") is True
+        plane_adapter.client.delete.assert_awaited_with("/issues/issue-1/")
+
+    @pytest.mark.asyncio
+    async def test_delete_issue_failure(self, plane_adapter):
+        """delete() returns False on client error."""
+        plane_adapter.client.delete.side_effect = PlaneClientError("boom")
+        assert await plane_adapter.delete("issue-1") is False
+
+    @pytest.mark.asyncio
+    async def test_list_with_state_filter(self, plane_adapter):
+        """list() maps issues and applies a client-side state filter."""
+        issues = [
+            dict(SAMPLE_ISSUE, id="a", state="state-prog"),
+            dict(SAMPLE_ISSUE, id="b", state="state-done"),
+        ]
+        plane_adapter.client.get_paginated.return_value = issues
+
+        results = await plane_adapter.list(filters={"state": TicketState.DONE})
+        assert [t.id for t in results] == ["b"]
+
+    @pytest.mark.asyncio
+    async def test_search_text_filter(self, plane_adapter):
+        """search() applies client-side text matching over titles."""
+        issues = [
+            dict(SAMPLE_ISSUE, id="a", name="Login bug"),
+            dict(SAMPLE_ISSUE, id="b", name="Dashboard tweak"),
+        ]
+        plane_adapter.client.get_paginated.return_value = issues
+
+        results = await plane_adapter.search(SearchQuery(query="login"))
+        assert [t.id for t in results] == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+
+class TestComments:
+    """Comment add/list."""
+
+    @pytest.mark.asyncio
+    async def test_add_comment(self, plane_adapter):
+        """add_comment() posts comment_html and maps the response."""
+        plane_adapter.client.post.return_value = {
+            "id": "c1",
+            "comment_html": "<p>hi</p>",
+            "actor": "user-1",
+            "created_at": "2024-11-15T10:30:00.000000Z",
+        }
+        comment = Comment(ticket_id="issue-1", content="<p>hi</p>")
+        result = await plane_adapter.add_comment(comment)
+
+        assert result.id == "c1"
+        assert result.ticket_id == "issue-1"
+        endpoint, payload = plane_adapter.client.post.await_args.args
+        assert endpoint == "/issues/issue-1/comments/"
+        assert payload["comment_html"] == "<p>hi</p>"
+
+    @pytest.mark.asyncio
+    async def test_get_comments(self, plane_adapter):
+        """get_comments() maps and paginates comment results."""
+        plane_adapter.client.get_paginated.return_value = [
+            {"id": "c1", "comment_html": "<p>one</p>"},
+            {"id": "c2", "comment_html": "<p>two</p>"},
+        ]
+        results = await plane_adapter.get_comments("issue-1", limit=1)
+        assert len(results) == 1
+        assert results[0].id == "c1"
+
+
+# ---------------------------------------------------------------------------
+# Milestones (Plane modules)
+# ---------------------------------------------------------------------------
+
+
+class TestMilestones:
+    """Milestone operations mapped onto Plane modules."""
+
+    @pytest.mark.asyncio
+    async def test_milestone_create(self, plane_adapter):
+        """milestone_create() posts a module and maps progress."""
+        plane_adapter.client.post.return_value = {
+            "id": "mod-1",
+            "name": "v2.0",
+            "status": "planned",
+            "total_issues": 10,
+            "completed_issues": 4,
+        }
+        milestone = await plane_adapter.milestone_create(name="v2.0")
+        assert milestone.id == "mod-1"
+        assert milestone.state == "open"
+        assert milestone.progress_pct == 40.0
+
+    @pytest.mark.asyncio
+    async def test_milestone_list_filter(self, plane_adapter):
+        """milestone_list() filters by universal milestone state."""
+        plane_adapter.client.get_paginated.return_value = [
+            {"id": "m1", "name": "A", "status": "completed"},
+            {"id": "m2", "name": "B", "status": "in-progress"},
+        ]
+        results = await plane_adapter.milestone_list(state="completed")
+        assert [m.id for m in results] == ["m1"]
+
+    @pytest.mark.asyncio
+    async def test_milestone_delete(self, plane_adapter):
+        """milestone_delete() returns True and hits the modules endpoint."""
+        plane_adapter.client.delete.return_value = {}
+        assert await plane_adapter.milestone_delete("mod-1") is True
+        plane_adapter.client.delete.assert_awaited_with("/modules/mod-1/")
+
+    @pytest.mark.asyncio
+    async def test_milestone_get_issues_inlined(self, plane_adapter):
+        """milestone_get_issues() maps inlined issue details from module links."""
+        plane_adapter.client.get_paginated.return_value = [
+            {"id": "link-1", "issue_detail": dict(SAMPLE_ISSUE, id="issue-9")},
+        ]
+        results = await plane_adapter.milestone_get_issues("mod-1")
+        assert [t.id for t in results] == ["issue-9"]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """Adapter registry wiring."""
+
+    def test_plane_registered(self):
+        """Importing the package registers the 'plane' adapter."""
+        assert AdapterRegistry.is_registered("plane")
+        assert AdapterRegistry.list_adapters()["plane"] is PlaneAdapter
+
+    def test_get_adapter_from_registry(self):
+        """The registry can build a PlaneAdapter from config."""
+        with patch.object(PlaneAdapter, "__init__", return_value=None) as init:
+            AdapterRegistry.get_adapter(
+                "plane",
+                {
+                    "api_key": "k",
+                    "workspace_slug": "ws",
+                    "project_id": "p",
+                },
+                force_new=True,
+            )
+            init.assert_called_once()
+
+
+class TestPlaneInstanceUrlSSRF:
+    """normalize_instance_url SSRF guard (xander review): block metadata/loopback/
+    link-local; ALLOW RFC-1918 (self-hosted Plane on an internal network is legit)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://127.0.0.1",
+            "https://[::1]",
+            "https://169.254.169.254",
+            "https://localhost",
+            "https://metadata.google.internal",
+        ],
+    )
+    def test_blocks_loopback_linklocal_and_metadata(self, url):
+        with pytest.raises(PlaneClientError):
+            normalize_instance_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        ["https://plane.example.com", "https://10.0.0.5", "https://192.168.1.10"],
+    )
+    def test_allows_public_and_private_self_host(self, url):
+        assert normalize_instance_url(url).startswith("https://")
+
+    def test_rejects_http(self):
+        with pytest.raises(PlaneClientError):
+            normalize_instance_url("http://plane.example.com")


### PR DESCRIPTION
Adds a complete **Plane.so** backend adapter (cloud + self-hosted), modeled on the existing Asana REST adapter and registered as `plane`.

## What's implemented
Full `BaseAdapter` contract:
- CRUD: `create` / `read` / `update` / `delete` / `list` / `search`
- `transition_state` — resolves Plane's **per-project workflow-state UUIDs** ⇄ `TicketState` (the main mapping work; modeled on how Linear resolves states)
- `add_comment` / `get_comments`, `search_users`
- **Milestones → Plane modules**: `milestone_create/get/list/update/delete/get_issues`
- Sub-issues → `list_tasks_by_issue`; Plane projects → Epic reads (`get_epic`/`project_get`/`project_list`/`list_issues_by_epic`)

Wiring: registered in `adapters/__init__.py`; env auto-discovery for `PLANE_API_KEY` / `PLANE_INSTANCE_URL` / `PLANE_WORKSPACE_SLUG` / `PLANE_PROJECT_ID` (+ `MCP_TICKETER_PLANE_*` aliases); `.env.example` + README sections.

## Security
- API key travels **only** in the `X-API-Key` header — never logged, never in URLs/exceptions.
- `instance_url` forced to https; redirects disabled with explicit cross-host refusal; error bodies not echoed; `Retry-After` bounded.
- **SSRF guard** on `instance_url`: blocks loopback / link-local / cloud-metadata hosts, while intentionally **allowing RFC-1918** addresses — a self-hosted Plane on an internal network is a primary use case, so blanket private-IP rejection would break legitimate deployments.

## Intentional `NotImplementedError` (documented in the adapter docstring)
Plane project *creation* (admin/workspace scope, outside the project-scoped API key), the `project_create/update/delete` lifecycle, and file attachments (Plane's S3-presign upload flow is out of scope for a REST CRUD adapter). Issue creation is fully implemented.

## Testing
- **48 unit tests** (mocked HTTP): CRUD, comments, state/priority mapping, milestones, registration, credential-not-in-URL, and the SSRF guard.
- **Verified live end-to-end** against a real self-hosted Plane instance: create → read → comment → transition → search → delete round-trips correctly.
- `ruff` + `mypy` clean on the new package.

Happy to adjust naming/scope to match maintainer preference.