### PR TITLE
Add ClickUp backend adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,36 @@ JIRA_PROJECT_KEY=PROJ
 # MCP_TICKETER_JIRA_SERVER=...
 
 # ============================================================================
+# ClickUp Configuration
+# ============================================================================
+# ClickUp personal API token (format: pk_...)
+# Generate at: https://app.clickup.com/settings/apps (Apps -> API Token)
+CLICKUP_API_TOKEN=pk_YOUR_TOKEN_HERE
+
+# Workspace (a.k.a. "team") id. Find it in the URL after logging in:
+# https://app.clickup.com/<TEAM_ID>/...
+CLICKUP_TEAM_ID=YOUR_TEAM_ID
+
+# Default list id for task creation (issues are created here unless an Epic /
+# parent_epic list id is provided). Find it in a list URL:
+# https://app.clickup.com/<team>/v/li/<LIST_ID>
+CLICKUP_LIST_ID=YOUR_LIST_ID
+
+# Optional: scope Epic (list) creation/listing to a space or folder.
+# CLICKUP_SPACE_ID=YOUR_SPACE_ID
+# CLICKUP_FOLDER_ID=YOUR_FOLDER_ID
+
+# Alternative naming conventions also supported:
+# CLICKUP_TOKEN=...
+# CLICKUP_API_KEY=...
+# MCP_TICKETER_CLICKUP_API_TOKEN=...
+# MCP_TICKETER_CLICKUP_TEAM_ID=...
+# MCP_TICKETER_CLICKUP_LIST_ID=...
+#
+# Note: ClickUp has no native milestone concept (Goals differ semantically),
+# so milestone operations are not supported by this adapter.
+
+# ============================================================================
 # AITrackdown Configuration
 # ============================================================================
 # Base path for local ticket storage (defaults to .aitrackdown)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Universal ticket management interface for AI agents with MCP (Model Context Prot
 ## 🚀 Features
 
 - **🎯 Universal Ticket Model**: Simplified to Epic, Task, and Comment types
-- **🔌 Multiple Adapters**: Support for JIRA, Linear, GitHub Issues, and AI-Trackdown
+- **🔌 Multiple Adapters**: Support for JIRA, Linear, GitHub Issues, Asana, ClickUp, and AI-Trackdown
 - **🤖 MCP Integration**: Native support for AI agent interactions
 - **⚡ High Performance**: Smart caching and async operations
 - **🎨 Rich CLI**: Beautiful terminal interface with colors and tables
@@ -1067,6 +1067,45 @@ Linear project and issue URLs work with any path suffix (`/issues`, `/overview`,
 **Finding your team information:**
 1. **Easiest**: Copy the URL from your Linear team's issues page
 2. **Alternative**: Go to Linear Settings → Teams → Your Team → "Key" field (e.g., "ENG", "DESIGN", "PRODUCT")
+
+### ClickUp Configuration
+
+Configure ClickUp with a personal API token plus your workspace (team) and a
+default list:
+
+```bash
+# In .env or environment
+CLICKUP_API_TOKEN=pk_...        # ClickUp -> Settings -> Apps -> API Token
+CLICKUP_TEAM_ID=9007012345      # Workspace id (from the app URL after login)
+CLICKUP_LIST_ID=901234567       # Default list new tasks/issues are created in
+
+# Optional: scope Epic (list) creation/listing to a space or folder
+# CLICKUP_SPACE_ID=90120001
+# CLICKUP_FOLDER_ID=90130002
+```
+
+**Hierarchy mapping:**
+
+| Universal | ClickUp        |
+|-----------|----------------|
+| Epic      | List           |
+| Issue     | Task (no parent) |
+| Task      | Subtask (has parent) |
+
+**State mapping:** ClickUp statuses are defined *per list*. The adapter reads
+each list's statuses (`GET /list/{id}`) and maps the status `type`
+(`open`/`custom`/`done`/`closed`) and name to the universal `TicketState`,
+resolving the reverse direction to a concrete status name that exists in the
+target list.
+
+**Limitations:** ClickUp has **no native milestone concept** (ClickUp Goals
+have different semantics — they aggregate targets/key-results rather than
+grouping issues by label under a due date), so the `milestone_*` operations
+are not supported and raise `NotImplementedError`.
+
+**Finding your ids:**
+1. **Team (workspace) id**: the number right after `app.clickup.com/` in the URL.
+2. **List id**: open a list, copy the number after `/v/li/` in the URL.
 
 ### Environment Variables
 

--- a/src/mcp_ticketer/adapters/__init__.py
+++ b/src/mcp_ticketer/adapters/__init__.py
@@ -2,6 +2,7 @@
 
 from .aitrackdown import AITrackdownAdapter
 from .asana import AsanaAdapter
+from .clickup import ClickUpAdapter
 from .github import GitHubAdapter
 from .hybrid import HybridAdapter
 from .jira import JiraAdapter
@@ -10,6 +11,7 @@ from .linear import LinearAdapter
 __all__ = [
     "AITrackdownAdapter",
     "AsanaAdapter",
+    "ClickUpAdapter",
     "LinearAdapter",
     "JiraAdapter",
     "GitHubAdapter",

--- a/src/mcp_ticketer/adapters/clickup/__init__.py
+++ b/src/mcp_ticketer/adapters/clickup/__init__.py
@@ -1,0 +1,19 @@
+"""ClickUp adapter for mcp-ticketer.
+
+This adapter integrates with ClickUp's REST API v2, supporting ticket
+management operations including:
+
+- CRUD operations for lists (epics) and tasks
+- Hierarchical structure (Epic -> Issue -> Task via List -> Task -> Subtask)
+- State transitions via per-list ClickUp statuses
+- User assignment and tag management
+- Comment support
+
+Milestones are not supported: ClickUp has no native milestone primitive
+(Goals differ semantically), so the ``milestone_*`` methods raise
+``NotImplementedError``.
+"""
+
+from .adapter import ClickUpAdapter
+
+__all__ = ["ClickUpAdapter"]

--- a/src/mcp_ticketer/adapters/clickup/adapter.py
+++ b/src/mcp_ticketer/adapters/clickup/adapter.py
@@ -1,0 +1,1125 @@
+"""Main ClickUpAdapter class for ClickUp REST API v2 integration.
+
+Milestone support
+-----------------
+ClickUp has no native milestone primitive. ClickUp "Goals" are a separate
+object with different semantics (they aggregate "targets"/key-results across
+spaces, not a label-grouped set of issues with a target date), so they cannot
+be mapped cleanly onto the universal ``Milestone`` model. All ``milestone_*``
+methods therefore raise ``NotImplementedError`` with an explanatory message
+rather than faking support. See the individual method docstrings.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+from ...core.adapter import BaseAdapter
+from ...core.models import (
+    Comment,
+    Epic,
+    Milestone,
+    Priority,
+    SearchQuery,
+    Task,
+    TicketState,
+    TicketType,
+)
+from ...core.registry import AdapterRegistry
+from .client import ClickUpClient
+from .mappers import (
+    map_clickup_comment_to_comment,
+    map_clickup_list_to_epic,
+    map_clickup_task_to_task,
+    map_task_to_clickup_payload,
+)
+from .types import map_priority_to_clickup, resolve_state_to_status_name
+
+logger = logging.getLogger(__name__)
+
+# Message used by all milestone_* methods (ClickUp has no native milestones).
+_MILESTONE_UNSUPPORTED = (
+    "ClickUp has no native milestone concept; Goals differ semantically "
+    "(target/key-result aggregation, not label-grouped issues with a due date) "
+    "— not supported in v1."
+)
+
+
+class ClickUpAdapter(BaseAdapter[Task]):
+    """Adapter for ClickUp task management using REST API v2.
+
+    Provides integration with ClickUp's REST API, supporting the major ticket
+    management operations:
+
+    - CRUD operations for lists (epics) and tasks
+    - Epic/Issue/Task hierarchy support
+    - State transitions via per-list statuses
+    - User assignment and tag management
+    - Comment management
+
+    Hierarchy Mapping:
+    - Epic  -> ClickUp List
+    - Issue -> ClickUp Task (in a list, no parent task)
+    - Task  -> ClickUp Subtask (has a parent task)
+
+    Note:
+        Milestones are not supported (ClickUp has no native milestone object).
+    """
+
+    def __init__(self, config: dict[str, Any]):
+        """Initialize the ClickUp adapter.
+
+        Args:
+            config: Configuration with:
+                - api_token / api_key: ClickUp personal token (``pk_...``) or
+                  ``CLICKUP_API_TOKEN`` env var.
+                - team_id / workspace_id: ClickUp workspace (team) id (optional;
+                  also read from ``CLICKUP_TEAM_ID``).
+                - list_id: default list id for task creation (optional; also read
+                  from ``CLICKUP_LIST_ID``).
+                - space_id / folder_id: optional scoping ids.
+                - timeout: request timeout in seconds (default 30).
+                - max_retries: maximum retry attempts (default 3).
+
+        Raises:
+            ValueError: If the required API token is missing.
+
+        """
+        # Set instance attributes before super().__init__ (which calls
+        # _get_state_mapping, mirroring the Asana adapter ordering).
+        self._team_id: str | None = None
+        self._default_list_id: str | None = None
+        self._space_id: str | None = None
+        self._folder_id: str | None = None
+        # Cache: list_id -> ordered list of status objects from GET /list/{id}.
+        self._list_statuses_cache: dict[str, list[dict[str, Any]]] = {}
+        self._initialized = False
+
+        super().__init__(config)
+
+        # Extract token from config or environment.
+        self.api_token = (
+            config.get("api_token")
+            or config.get("api_key")
+            or os.getenv("CLICKUP_API_TOKEN")
+            or os.getenv("MCP_TICKETER_CLICKUP_API_TOKEN")
+        )
+        if not self.api_token:
+            raise ValueError(
+                "ClickUp API token is required (api_token or CLICKUP_API_TOKEN env var)"
+            )
+
+        # Strip an accidental "NAME=value" prefix (mirrors Asana hardening).
+        if isinstance(self.api_token, str) and "=" in self.api_token:
+            parts = self.api_token.split("=", 1)
+            if len(parts) == 2 and parts[0].upper() in (
+                "CLICKUP_API_TOKEN",
+                "CLICKUP_TOKEN",
+                "CLICKUP_API_KEY",
+                "API_TOKEN",
+                "API_KEY",
+            ):
+                self.api_token = parts[1]
+
+        # Optional scoping configuration (config wins over env).
+        self._team_id = (
+            config.get("team_id")
+            or config.get("workspace_id")
+            or os.getenv("CLICKUP_TEAM_ID")
+            or os.getenv("MCP_TICKETER_CLICKUP_TEAM_ID")
+        )
+        self._default_list_id = (
+            config.get("list_id")
+            or config.get("default_list_id")
+            or os.getenv("CLICKUP_LIST_ID")
+            or os.getenv("MCP_TICKETER_CLICKUP_LIST_ID")
+        )
+        self._space_id = config.get("space_id") or os.getenv("CLICKUP_SPACE_ID")
+        self._folder_id = config.get("folder_id") or os.getenv("CLICKUP_FOLDER_ID")
+
+        timeout = config.get("timeout", 30)
+        max_retries = config.get("max_retries", 3)
+
+        self.client = ClickUpClient(
+            self.api_token, timeout=timeout, max_retries=max_retries
+        )
+
+    def _get_state_mapping(self) -> dict[TicketState, str]:
+        """Get the mapping from universal states to ClickUp status categories.
+
+        ClickUp statuses are defined per-list, so this mapping is only the
+        coarse "type category" each universal state belongs to. The concrete
+        per-list status NAME is resolved at write time against the target list's
+        statuses (see ``_resolve_status_name``).
+
+        Returns:
+            Dictionary mapping ``TicketState`` to a ClickUp status type
+            ("open", "custom", "done", "closed").
+
+        """
+        return {
+            TicketState.OPEN: "open",
+            TicketState.IN_PROGRESS: "custom",
+            TicketState.READY: "custom",
+            TicketState.TESTED: "custom",
+            TicketState.DONE: "done",
+            TicketState.WAITING: "custom",
+            TicketState.BLOCKED: "custom",
+            TicketState.CLOSED: "closed",
+        }
+
+    def validate_credentials(self) -> tuple[bool, str]:
+        """Validate that the ClickUp API token is present.
+
+        Returns:
+            Tuple of (is_valid, error_message).
+
+        """
+        if not self.api_token:
+            return False, "ClickUp API token is required"
+        return True, ""
+
+    async def initialize(self) -> None:
+        """Initialize the adapter by verifying credentials and resolving the team."""
+        if self._initialized:
+            return
+
+        try:
+            if not await self.client.test_connection():
+                raise ValueError("Failed to connect to ClickUp API - check credentials")
+
+            # Resolve a default team (workspace) if none was provided.
+            if not self._team_id:
+                await self._resolve_team()
+
+            self._initialized = True
+            logger.info(
+                "ClickUp adapter initialized (team_id=%s, default_list_id=%s)",
+                self._team_id,
+                self._default_list_id,
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to initialize ClickUp adapter: {e}") from e
+
+    async def _resolve_team(self) -> None:
+        """Resolve the default team (workspace) id via ``GET /team``."""
+        try:
+            response = await self.client.get("/team")
+            teams = response.get("teams", [])
+            if teams:
+                self._team_id = str(teams[0].get("id"))
+                logger.info(
+                    "Resolved ClickUp team: %s (id=%s)",
+                    teams[0].get("name"),
+                    self._team_id,
+                )
+            else:
+                logger.warning("No ClickUp teams (workspaces) found for this token")
+        except Exception as e:
+            logger.warning("Failed to resolve ClickUp team: %s", e)
+
+    # ------------------------------------------------------------------
+    # Status / list helpers (the core of the ClickUp state-mapping work)
+    # ------------------------------------------------------------------
+
+    async def _load_list_statuses(self, list_id: str) -> list[dict[str, Any]]:
+        """Load the ordered set of statuses configured for a ClickUp list.
+
+        ClickUp statuses are per-list. ``GET /list/{list_id}`` returns a
+        ``statuses`` array of objects shaped
+        ``{"status": "in progress", "type": "custom", "orderindex": 1, ...}``.
+
+        Args:
+            list_id: ClickUp list id.
+
+        Returns:
+            List of status objects (empty list on failure).
+
+        """
+        try:
+            list_obj = await self.client.get(f"/list/{list_id}")
+            statuses = list_obj.get("statuses", [])
+            if isinstance(statuses, list):
+                return statuses
+            return []
+        except Exception as e:
+            logger.warning("Failed to load statuses for list %s: %s", list_id, e)
+            return []
+
+    async def _get_list_statuses(self, list_id: str) -> list[dict[str, Any]]:
+        """Get a list's statuses, loading and caching them on first access.
+
+        Args:
+            list_id: ClickUp list id.
+
+        Returns:
+            Ordered list of status objects.
+
+        """
+        if list_id not in self._list_statuses_cache:
+            self._list_statuses_cache[list_id] = await self._load_list_statuses(list_id)
+        return self._list_statuses_cache[list_id]
+
+    async def _resolve_status_name(
+        self, state: TicketState, list_id: str | None
+    ) -> str | None:
+        """Resolve a universal state to a concrete per-list status name.
+
+        Args:
+            state: Universal ticket state.
+            list_id: Target ClickUp list id (None -> cannot resolve).
+
+        Returns:
+            A status name that exists in the list, or None if unresolvable.
+
+        """
+        if not list_id:
+            return None
+        statuses = await self._get_list_statuses(list_id)
+        return resolve_state_to_status_name(state, statuses)
+
+    async def _task_list_id(self, ticket_id: str) -> str | None:
+        """Look up the list id a task belongs to (needed for status resolution).
+
+        Args:
+            ticket_id: ClickUp task id.
+
+        Returns:
+            The task's list id, or None if not found.
+
+        """
+        try:
+            task = await self.client.get(f"/task/{ticket_id}")
+            list_obj = task.get("list") or {}
+            list_id = list_obj.get("id") if isinstance(list_obj, dict) else None
+            return str(list_id) if list_id is not None else None
+        except Exception as e:
+            logger.error("Failed to look up list for task %s: %s", ticket_id, e)
+            return None
+
+    def _resolve_list_id_for_create(self, task: Task) -> str | None:
+        """Determine which list a new task/issue should be created in.
+
+        Resolution order:
+        1. ``task.parent_epic`` (Epic == ClickUp List).
+        2. The adapter's configured default list id.
+
+        Subtasks (``task.parent_issue`` set) inherit the parent's list, so a
+        list id is not strictly required for them; ClickUp still requires a list
+        endpoint, so the default list is used as the creation endpoint and the
+        ``parent`` field links it to the parent task.
+
+        Args:
+            task: Task being created.
+
+        Returns:
+            Target list id, or None if none can be determined.
+
+        """
+        if task.parent_epic:
+            return str(task.parent_epic)
+        if self._default_list_id:
+            return str(self._default_list_id)
+        return None
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+
+    async def create(self, ticket: Epic | Task) -> Epic | Task:  # type: ignore[override]
+        """Create a new ClickUp list (Epic) or task (Issue/Task).
+
+        Args:
+            ticket: Epic or Task to create.
+
+        Returns:
+            Created ticket with its id populated.
+
+        Raises:
+            ValueError: If creation fails.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        await self.initialize()
+
+        if isinstance(ticket, Epic):
+            return await self._create_epic(ticket)
+        return await self._create_task(ticket)
+
+    async def _create_epic(self, epic: Epic) -> Epic:
+        """Create a ClickUp list from an Epic.
+
+        A list is created inside a folder (if ``folder_id`` is configured) or
+        "folderless" inside a space (if ``space_id`` is configured).
+
+        Args:
+            epic: Epic to create.
+
+        Returns:
+            Created epic with ClickUp metadata.
+
+        Raises:
+            ValueError: If no folder/space is configured, or creation fails.
+
+        """
+        payload: dict[str, Any] = {"name": epic.title}
+        if epic.description:
+            payload["content"] = epic.description
+
+        try:
+            if self._folder_id:
+                created = await self.client.post(
+                    f"/folder/{self._folder_id}/list", payload
+                )
+            elif self._space_id:
+                created = await self.client.post(
+                    f"/space/{self._space_id}/list", payload
+                )
+            else:
+                raise ValueError(
+                    "Creating an Epic (ClickUp list) requires a configured "
+                    "folder_id (CLICKUP_FOLDER_ID) or space_id (CLICKUP_SPACE_ID)"
+                )
+            return map_clickup_list_to_epic(created)
+        except ValueError:
+            raise
+        except Exception as e:
+            raise ValueError(f"Failed to create ClickUp list: {e}") from e
+
+    async def _create_task(self, task: Task) -> Task:
+        """Create a ClickUp task or subtask from a Task.
+
+        Args:
+            task: Task to create.
+
+        Returns:
+            Created task with ClickUp metadata.
+
+        Raises:
+            ValueError: If no target list can be resolved or creation fails.
+
+        """
+        list_id = self._resolve_list_id_for_create(task)
+        if not list_id:
+            raise ValueError(
+                "Creating a task requires a target list: set parent_epic (a "
+                "ClickUp list id) or configure a default list_id (CLICKUP_LIST_ID)"
+            )
+
+        payload = map_task_to_clickup_payload(task)
+
+        # Resolve assignee (ClickUp expects integer user ids).
+        if task.assignee:
+            assignee_id = self._coerce_user_id(task.assignee)
+            if assignee_id is not None:
+                payload["assignees"] = [assignee_id]
+            else:
+                logger.warning(
+                    "Could not coerce assignee '%s' to a ClickUp user id",
+                    task.assignee,
+                )
+
+        # Resolve a concrete per-list status name from the requested state.
+        if task.state and task.state != TicketState.OPEN:
+            status_name = await self._resolve_status_name(task.state, list_id)
+            if status_name:
+                payload["status"] = status_name
+
+        try:
+            created = await self.client.post(f"/list/{list_id}/task", payload)
+            # Re-read so we get the fully-populated task (status object, list, etc.).
+            full = await self.client.get(f"/task/{created['id']}")
+            return map_clickup_task_to_task(full)
+        except Exception as e:
+            raise ValueError(f"Failed to create ClickUp task: {e}") from e
+
+    def _coerce_user_id(self, user_identifier: str) -> int | None:
+        """Coerce a user identifier to a ClickUp integer user id.
+
+        ClickUp assignees are integer user ids. This adapter accepts a numeric
+        id (as int or string); non-numeric identifiers (names/emails) cannot be
+        resolved without a members lookup and are rejected here.
+
+        Args:
+            user_identifier: User id as a string.
+
+        Returns:
+            Integer user id, or None if not numeric.
+
+        """
+        if user_identifier is None:
+            return None
+        try:
+            return int(user_identifier)
+        except (ValueError, TypeError):
+            return None
+
+    async def read(self, ticket_id: str) -> Task | None:
+        """Read a ClickUp task by id.
+
+        Args:
+            ticket_id: ClickUp task id.
+
+        Returns:
+            Task if found, None otherwise.
+
+        Raises:
+            ValueError: If credentials are invalid.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        try:
+            task = await self.client.get(f"/task/{ticket_id}")
+            return map_clickup_task_to_task(task)
+        except Exception as e:
+            logger.error("Failed to read task %s: %s", ticket_id, e)
+            return None
+
+    async def update(self, ticket_id: str, updates: dict[str, Any]) -> Task | None:
+        """Update a ClickUp task.
+
+        Args:
+            ticket_id: ClickUp task id.
+            updates: Fields to update. Recognised keys: ``title``,
+                ``description``, ``priority``, ``state``, ``assignee``,
+                ``due_date``, ``tags``.
+
+        Returns:
+            Updated task, or None on failure.
+
+        Raises:
+            ValueError: If credentials are invalid.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        try:
+            payload: dict[str, Any] = {}
+
+            if "title" in updates:
+                payload["name"] = updates["title"]
+
+            if "description" in updates:
+                payload["description"] = updates["description"]
+
+            if "priority" in updates:
+                payload["priority"] = self._coerce_priority_update(updates["priority"])
+
+            if "assignee" in updates and updates["assignee"]:
+                assignee_id = self._coerce_user_id(updates["assignee"])
+                if assignee_id is not None:
+                    # ClickUp PUT uses {"assignees": {"add": [...], "rem": [...]}}.
+                    payload["assignees"] = {"add": [assignee_id]}
+
+            if "due_date" in updates:
+                payload["due_date"] = updates["due_date"]
+
+            if "state" in updates:
+                state = updates["state"]
+                if isinstance(state, str):
+                    state = TicketState(state)
+                list_id = await self._task_list_id(ticket_id)
+                status_name = await self._resolve_status_name(state, list_id)
+                if status_name:
+                    payload["status"] = status_name
+                else:
+                    logger.warning(
+                        "Could not resolve a list status for state %s on task %s",
+                        state,
+                        ticket_id,
+                    )
+
+            if payload:
+                await self.client.put(f"/task/{ticket_id}", payload)
+
+            # Tags are updated via dedicated endpoints (not the task PUT body).
+            if "tags" in updates:
+                await self._replace_tags(ticket_id, updates.get("tags") or [])
+
+            full = await self.client.get(f"/task/{ticket_id}")
+            return map_clickup_task_to_task(full)
+        except Exception as e:
+            logger.error("Failed to update task %s: %s", ticket_id, e)
+            return None
+
+    def _coerce_priority_update(self, value: Any) -> int:
+        """Coerce a priority update value to a ClickUp integer priority code.
+
+        Accepts a ``Priority`` enum, its string value, or a raw ClickUp int.
+
+        Args:
+            value: Priority enum, string, or int.
+
+        Returns:
+            ClickUp integer priority (1=urgent..4=low; defaults to 3=normal).
+
+        """
+        if isinstance(value, int):
+            return value
+        if isinstance(value, Priority):
+            return map_priority_to_clickup(value)
+        if isinstance(value, str):
+            try:
+                return map_priority_to_clickup(Priority(value.lower()))
+            except ValueError:
+                return 3
+        return 3
+
+    async def _replace_tags(self, ticket_id: str, new_tags: list[str]) -> None:
+        """Replace a task's tags with ``new_tags``.
+
+        ClickUp manages tags via ``POST/DELETE /task/{id}/tag/{tag_name}``.
+
+        Args:
+            ticket_id: ClickUp task id.
+            new_tags: Desired set of tag names.
+
+        """
+        try:
+            current = await self.client.get(f"/task/{ticket_id}")
+            existing = [
+                t.get("name")
+                for t in current.get("tags", [])
+                if isinstance(t, dict) and t.get("name")
+            ]
+
+            for tag_name in existing:
+                if tag_name not in new_tags:
+                    try:
+                        await self.client.delete(f"/task/{ticket_id}/tag/{tag_name}")
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to remove tag '%s' from task %s: %s",
+                            tag_name,
+                            ticket_id,
+                            e,
+                        )
+
+            for tag_name in new_tags:
+                if tag_name not in existing:
+                    try:
+                        await self.client.post(f"/task/{ticket_id}/tag/{tag_name}", {})
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to add tag '%s' to task %s: %s",
+                            tag_name,
+                            ticket_id,
+                            e,
+                        )
+        except Exception as e:
+            logger.warning("Failed to replace tags for task %s: %s", ticket_id, e)
+
+    async def delete(self, ticket_id: str) -> bool:
+        """Delete a ClickUp task.
+
+        Args:
+            ticket_id: ClickUp task id.
+
+        Returns:
+            True if deleted, False otherwise.
+
+        """
+        try:
+            await self.client.delete(f"/task/{ticket_id}")
+            return True
+        except Exception as e:
+            logger.error("Failed to delete task %s: %s", ticket_id, e)
+            return False
+
+    async def list(
+        self, limit: int = 10, offset: int = 0, filters: dict[str, Any] | None = None
+    ) -> builtins.list[Task]:
+        """List ClickUp tasks with optional filtering.
+
+        Tasks are fetched from a list endpoint (``GET /list/{id}/task``). The
+        target list is taken from ``filters['parent_epic']`` / ``filters['project']``
+        or the adapter's default list id.
+
+        Args:
+            limit: Maximum number of tasks to return.
+            offset: Number of tasks to skip (ClickUp paginates by page; the
+                ``page`` derived from offset/limit is used).
+            filters: Optional filters (``parent_epic``/``project``, ``state``,
+                ``ticket_type``).
+
+        Returns:
+            List of tasks matching the criteria.
+
+        Raises:
+            ValueError: If credentials are invalid.
+
+        """
+        is_valid, error_message = self.validate_credentials()
+        if not is_valid:
+            raise ValueError(error_message)
+
+        await self.initialize()
+
+        filters = filters or {}
+
+        list_id = (
+            filters.get("parent_epic")
+            or filters.get("project")
+            or self._default_list_id
+        )
+        if not list_id:
+            logger.warning(
+                "ClickUp list() requires a list id (parent_epic/project filter "
+                "or default list_id); returning empty result"
+            )
+            return []
+
+        # ClickUp uses page-based pagination (100 tasks/page).
+        page = offset // limit if limit else 0
+        params: dict[str, Any] = {
+            "page": page,
+            "subtasks": "true",
+            "include_closed": "true",
+        }
+
+        try:
+            response = await self.client.get(f"/list/{list_id}/task", params=params)
+            raw_tasks = response.get("tasks", [])
+            tasks = [map_clickup_task_to_task(t) for t in raw_tasks]
+        except Exception as e:
+            logger.error("Failed to list tasks for list %s: %s", list_id, e)
+            return []
+
+        # Client-side filters (state / ticket_type).
+        if "state" in filters:
+            state = filters["state"]
+            if isinstance(state, str):
+                state = TicketState(state)
+            tasks = [t for t in tasks if t.state == state]
+
+        if "ticket_type" in filters:
+            ticket_type = filters["ticket_type"]
+            tasks = [t for t in tasks if t.ticket_type == ticket_type]
+
+        return tasks[:limit]
+
+    async def search(self, query: SearchQuery) -> builtins.list[Task]:
+        """Search ClickUp tasks using filters and client-side text matching.
+
+        Args:
+            query: Search query with filters.
+
+        Returns:
+            List of tasks matching the search criteria.
+
+        """
+        filters: dict[str, Any] = {}
+        if query.project:
+            filters["parent_epic"] = query.project
+        if query.state:
+            filters["state"] = query.state
+
+        tasks = await self.list(limit=query.limit, offset=query.offset, filters=filters)
+
+        if query.query:
+            query_lower = query.query.lower()
+            tasks = [
+                t
+                for t in tasks
+                if query_lower in t.title.lower()
+                or (t.description and query_lower in t.description.lower())
+            ]
+
+        if query.assignee:
+            tasks = [t for t in tasks if t.assignee == query.assignee]
+
+        if query.tags:
+            tasks = [t for t in tasks if any(tag in t.tags for tag in query.tags)]
+
+        return tasks[: query.limit]
+
+    async def transition_state(
+        self, ticket_id: str, target_state: TicketState
+    ) -> Task | None:
+        """Transition a task to a new state.
+
+        Args:
+            ticket_id: ClickUp task id.
+            target_state: Target universal state.
+
+        Returns:
+            Updated task, or None on failure.
+
+        """
+        return await self.update(ticket_id, {"state": target_state})
+
+    async def add_comment(self, comment: Comment) -> Comment:
+        """Add a comment to a ClickUp task.
+
+        Args:
+            comment: Comment to add.
+
+        Returns:
+            Created comment with its id populated.
+
+        Raises:
+            ValueError: If comment creation fails.
+
+        """
+        try:
+            created = await self.client.post(
+                f"/task/{comment.ticket_id}/comment",
+                {"comment_text": comment.content},
+            )
+            # ClickUp returns {"id": ..., "hist_id": ..., "date": ...}; merge id
+            # into a comment shape the mapper understands.
+            created.setdefault("comment_text", comment.content)
+            return map_clickup_comment_to_comment(created, comment.ticket_id)
+        except Exception as e:
+            raise ValueError(f"Failed to add comment: {e}") from e
+
+    async def get_comments(
+        self, ticket_id: str, limit: int = 10, offset: int = 0
+    ) -> builtins.list[Comment]:
+        """Get comments for a ClickUp task.
+
+        Args:
+            ticket_id: ClickUp task id.
+            limit: Maximum number of comments to return.
+            offset: Number of comments to skip.
+
+        Returns:
+            List of comments for the task.
+
+        """
+        try:
+            response = await self.client.get(f"/task/{ticket_id}/comment")
+            raw_comments = response.get("comments", [])
+            comments = [
+                map_clickup_comment_to_comment(c, ticket_id) for c in raw_comments
+            ]
+            return comments[offset : offset + limit]
+        except Exception as e:
+            logger.error("Failed to get comments for task %s: %s", ticket_id, e)
+            return []
+
+    # ------------------------------------------------------------------
+    # Epic/Issue/Task hierarchy methods
+    # ------------------------------------------------------------------
+
+    async def get_epic(self, epic_id: str) -> Epic | None:
+        """Get a ClickUp list (Epic) by id.
+
+        Args:
+            epic_id: ClickUp list id.
+
+        Returns:
+            Epic if found, None otherwise.
+
+        """
+        try:
+            list_obj = await self.client.get(f"/list/{epic_id}")
+            return map_clickup_list_to_epic(list_obj)
+        except Exception as e:
+            logger.error("Failed to get list %s: %s", epic_id, e)
+            return None
+
+    async def list_epics(self, **kwargs: Any) -> builtins.list[Epic]:
+        """List ClickUp lists (Epics) within the configured folder/space.
+
+        Args:
+            **kwargs: Optional ``archived`` filter.
+
+        Returns:
+            List of epics.
+
+        """
+        await self.initialize()
+
+        try:
+            if self._folder_id:
+                response = await self.client.get(f"/folder/{self._folder_id}/list")
+            elif self._space_id:
+                response = await self.client.get(
+                    f"/space/{self._space_id}/list",
+                    params={"archived": "false"},
+                )
+            else:
+                logger.warning(
+                    "list_epics requires folder_id or space_id configuration"
+                )
+                return []
+
+            raw_lists = response.get("lists", [])
+            epics = [map_clickup_list_to_epic(item) for item in raw_lists]
+
+            if "archived" in kwargs:
+                archived = kwargs["archived"]
+                epics = [
+                    e for e in epics if e.metadata.get("clickup_archived") == archived
+                ]
+            return epics
+        except Exception as e:
+            logger.error("Failed to list lists (epics): %s", e)
+            return []
+
+    async def update_epic(self, epic_id: str, updates: dict[str, Any]) -> Epic | None:
+        """Update a ClickUp list (Epic).
+
+        Args:
+            epic_id: ClickUp list id.
+            updates: Recognised keys: ``title``, ``description``.
+
+        Returns:
+            Updated epic, or None on failure.
+
+        """
+        payload: dict[str, Any] = {}
+        if "title" in updates:
+            payload["name"] = updates["title"]
+        if "description" in updates:
+            payload["content"] = updates["description"]
+
+        try:
+            if payload:
+                await self.client.put(f"/list/{epic_id}", payload)
+            return await self.get_epic(epic_id)
+        except Exception as e:
+            logger.error("Failed to update list %s: %s", epic_id, e)
+            return None
+
+    async def delete_epic(self, epic_id: str) -> bool:
+        """Delete a ClickUp list (Epic).
+
+        Args:
+            epic_id: ClickUp list id.
+
+        Returns:
+            True if deleted, False otherwise.
+
+        """
+        try:
+            await self.client.delete(f"/list/{epic_id}")
+            return True
+        except Exception as e:
+            logger.error("Failed to delete list %s: %s", epic_id, e)
+            return False
+
+    async def list_issues_by_epic(self, epic_id: str) -> builtins.list[Task]:
+        """List all tasks in a ClickUp list (Epic).
+
+        Args:
+            epic_id: ClickUp list id.
+
+        Returns:
+            List of issues in the list.
+
+        """
+        return await self.list(
+            limit=100,
+            filters={"parent_epic": epic_id, "ticket_type": TicketType.ISSUE},
+        )
+
+    async def list_tasks_by_issue(self, issue_id: str) -> builtins.list[Task]:
+        """List all subtasks of a task (Issue).
+
+        ClickUp returns subtasks inline on the parent when requested with
+        ``include_subtasks``. Each child is fetched fully to populate its fields.
+
+        Args:
+            issue_id: Parent ClickUp task id.
+
+        Returns:
+            List of subtasks.
+
+        """
+        try:
+            parent = await self.client.get(
+                f"/task/{issue_id}", params={"include_subtasks": "true"}
+            )
+            subtasks = parent.get("subtasks", [])
+            tasks: list[Task] = []
+            for sub in subtasks:
+                sub_id = sub.get("id")
+                if not sub_id:
+                    continue
+                try:
+                    full = await self.client.get(f"/task/{sub_id}")
+                    tasks.append(map_clickup_task_to_task(full))
+                except Exception as e:
+                    logger.warning("Failed to read subtask %s: %s", sub_id, e)
+            return tasks
+        except Exception as e:
+            logger.error("Failed to list subtasks for task %s: %s", issue_id, e)
+            return []
+
+    async def search_users(self, query: str) -> builtins.list[dict[str, Any]]:
+        """Search for users (members) in the ClickUp workspace.
+
+        ClickUp exposes members via ``GET /team`` (each team carries a
+        ``members`` array). This performs a client-side case-insensitive match
+        on username/email.
+
+        Args:
+            query: Search query (username or email substring).
+
+        Returns:
+            List of user dicts with keys ``id``, ``name``, ``email``.
+
+        """
+        try:
+            response = await self.client.get("/team")
+            teams = response.get("teams", [])
+            results: list[dict[str, Any]] = []
+            query_lower = (query or "").lower()
+
+            for team in teams:
+                if self._team_id and str(team.get("id")) != str(self._team_id):
+                    continue
+                for member in team.get("members", []):
+                    user = member.get("user", {}) if isinstance(member, dict) else {}
+                    username = str(user.get("username") or "")
+                    email = str(user.get("email") or "")
+                    if (
+                        not query_lower
+                        or query_lower in username.lower()
+                        or query_lower in email.lower()
+                    ):
+                        results.append(
+                            {
+                                "id": str(user.get("id"))
+                                if user.get("id") is not None
+                                else None,
+                                "name": username,
+                                "email": email,
+                            }
+                        )
+            return results
+        except Exception as e:
+            logger.error("Failed to search ClickUp users: %s", e)
+            return []
+
+    async def close(self) -> None:
+        """Close the adapter and cleanup resources."""
+        await self.client.close()
+
+    # ------------------------------------------------------------------
+    # Milestone methods — NOT SUPPORTED (ClickUp has no native milestones)
+    # ------------------------------------------------------------------
+
+    async def milestone_create(
+        self,
+        name: str,
+        target_date: datetime | None = None,
+        labels: builtins.list[str] | None = None,
+        description: str = "",
+        project_id: str | None = None,
+    ) -> Milestone:
+        """Not supported — ClickUp has no native milestone concept.
+
+        Args:
+            name: Milestone name.
+            target_date: Target completion date.
+            labels: Labels that define this milestone.
+            description: Milestone description.
+            project_id: Associated project id.
+
+        Raises:
+            NotImplementedError: Always — see module docstring.
+
+        """
+        raise NotImplementedError(_MILESTONE_UNSUPPORTED)
+
+    async def milestone_get(self, milestone_id: str) -> Milestone | None:
+        """Not supported — ClickUp has no native milestone concept.
+
+        Args:
+            milestone_id: Milestone identifier.
+
+        Raises:
+            NotImplementedError: Always — see module docstring.
+
+        """
+        raise NotImplementedError(_MILESTONE_UNSUPPORTED)
+
+    async def milestone_list(
+        self,
+        project_id: str | None = None,
+        state: str | None = None,
+    ) -> builtins.list[Milestone]:
+        """Not supported — ClickUp has no native milestone concept.
+
+        Args:
+            project_id: Filter by project.
+            state: Filter by state.
+
+        Raises:
+            NotImplementedError: Always — see module docstring.
+
+        """
+        raise NotImplementedError(_MILESTONE_UNSUPPORTED)
+
+    async def milestone_update(
+        self,
+        milestone_id: str,
+        name: str | None = None,
+        target_date: datetime | None = None,
+        state: str | None = None,
+        labels: builtins.list[str] | None = None,
+        description: str | None = None,
+    ) -> Milestone | None:
+        """Not supported — ClickUp has no native milestone concept.
+
+        Args:
+            milestone_id: Milestone identifier.
+            name: New name.
+            target_date: New target date.
+            state: New state.
+            labels: New labels.
+            description: New description.
+
+        Raises:
+            NotImplementedError: Always — see module docstring.
+
+        """
+        raise NotImplementedError(_MILESTONE_UNSUPPORTED)
+
+    async def milestone_delete(self, milestone_id: str) -> bool:
+        """Not supported — ClickUp has no native milestone concept.
+
+        Args:
+            milestone_id: Milestone identifier.
+
+        Raises:
+            NotImplementedError: Always — see module docstring.
+
+        """
+        raise NotImplementedError(_MILESTONE_UNSUPPORTED)
+
+    async def milestone_get_issues(
+        self,
+        milestone_id: str,
+        state: str | None = None,
+    ) -> builtins.list[Task]:
+        """Not supported — ClickUp has no native milestone concept.
+
+        Args:
+            milestone_id: Milestone identifier.
+            state: Filter by issue state.
+
+        Raises:
+            NotImplementedError: Always — see module docstring.
+
+        """
+        raise NotImplementedError(_MILESTONE_UNSUPPORTED)
+
+
+# Register the adapter.
+AdapterRegistry.register("clickup", ClickUpAdapter)

--- a/src/mcp_ticketer/adapters/clickup/client.py
+++ b/src/mcp_ticketer/adapters/clickup/client.py
@@ -1,0 +1,279 @@
+"""ClickUp HTTP client for REST API v2."""
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from .types import CLICKUP_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+
+class ClickUpClient:
+    """HTTP client for ClickUp REST API v2.
+
+    Handles:
+    - Personal-token authentication (``Authorization: <token>``; no "Bearer").
+    - Rate limiting (429 with Retry-After) with bounded retries.
+    - Error handling for all status codes (raised as ``ValueError``).
+    - Timeout retries with exponential backoff.
+
+    Security:
+        The personal token is held on the instance and sent as the
+        ``Authorization`` header. It is never included in any log line or
+        exception message; only the request method, URL, and status are logged.
+    """
+
+    BASE_URL = CLICKUP_BASE_URL
+
+    def __init__(self, api_token: str, timeout: int = 30, max_retries: int = 3):
+        """Initialize ClickUp client.
+
+        Args:
+            api_token: ClickUp personal API token (format ``pk_...``).
+            timeout: Request timeout in seconds.
+            max_retries: Maximum retry attempts for rate limiting / timeouts.
+
+        """
+        self.api_token = api_token
+        self.timeout = timeout
+        self.max_retries = max_retries
+
+        # ClickUp authenticates with the raw token (NOT "Bearer <token>").
+        self.headers = {
+            "Authorization": api_token,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        # HTTP client (created lazily on first use).
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the async HTTP client.
+
+        Returns:
+            Configured async HTTP client.
+
+        """
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                headers=self.headers,
+                timeout=self.timeout,
+                follow_redirects=False,
+            )
+        return self._client
+
+    async def _handle_rate_limit(self, response: httpx.Response, attempt: int) -> None:
+        """Handle rate limiting with Retry-After backoff.
+
+        Args:
+            response: HTTP response with 429 status.
+            attempt: Current retry attempt number.
+
+        Raises:
+            ValueError: If max retries exceeded.
+
+        """
+        if attempt >= self.max_retries:
+            raise ValueError(
+                f"Max retries ({self.max_retries}) exceeded for rate limiting"
+            )
+
+        # ClickUp returns Retry-After in seconds; default to 60 if absent.
+        try:
+            retry_after = min(int(response.headers.get("Retry-After", "60")), 3600)
+        except (ValueError, TypeError):
+            retry_after = 60
+        logger.warning(
+            "Rate limited (429). Waiting %ss before retry %s/%s",
+            retry_after,
+            attempt + 1,
+            self.max_retries,
+        )
+        await asyncio.sleep(retry_after)
+
+    def _extract_error_detail(self, response: httpx.Response) -> str:
+        """Extract a human-readable error message from a ClickUp error response.
+
+        ClickUp errors are shaped ``{"err": "...", "ECODE": "..."}``.
+
+        Args:
+            response: HTTP response with a >= 400 status.
+
+        Returns:
+            Error message string (never contains the auth token).
+
+        """
+        # Never start from the raw body (it can echo request details); use
+        # the parsed ClickUp 'err' field when present, else a status-only message.
+        detail = response.reason_phrase or f"HTTP {response.status_code}"
+        try:
+            error_json = response.json()
+            if isinstance(error_json, dict):
+                detail = error_json.get("err") or error_json.get("error") or detail
+                ecode = error_json.get("ECODE")
+                if ecode:
+                    detail = f"{detail} (ECODE: {ecode})"
+        except Exception:
+            pass
+        return detail
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Make an HTTP request with retry logic for rate limiting and timeouts.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE).
+            endpoint: API endpoint (without base URL).
+            params: URL query parameters.
+            json: Request body JSON data.
+
+        Returns:
+            Parsed JSON response body (ClickUp does not wrap responses).
+
+        Raises:
+            ValueError: If the request fails or max retries are exceeded. The
+                error message never includes the authentication token.
+
+        """
+        client = await self._get_client()
+        url = f"{self.BASE_URL}/{endpoint.lstrip('/')}"
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await client.request(
+                    method=method,
+                    url=url,
+                    params=params,
+                    json=json,
+                )
+
+                # Refuse redirects: the base host is fixed (api.clickup.com); a 3xx
+                # could bounce the Authorization header to another host (xander review).
+                if response.is_redirect:
+                    raise ValueError(
+                        f"ClickUp API returned an unexpected redirect "
+                        f"(status {response.status_code}); refusing to follow"
+                    )
+
+                # Handle rate limiting.
+                if response.status_code == 429:
+                    await self._handle_rate_limit(response, attempt)
+                    continue
+
+                # Handle errors.
+                if response.status_code >= 400:
+                    detail = self._extract_error_detail(response)
+                    raise ValueError(
+                        f"ClickUp API error ({response.status_code}): {detail}"
+                    )
+
+                # Success. ClickUp returns the body directly (no {"data": ...}).
+                if not response.content:
+                    return {}
+                parsed = response.json()
+                if isinstance(parsed, dict):
+                    return parsed
+                # Some endpoints (rare) return a bare list; wrap for the typed signature.
+                return {"_list": parsed}
+
+            except httpx.TimeoutException as e:
+                # Do not interpolate the exception object that could carry headers;
+                # log only the method/url and a short reason.
+                logger.error("Request timeout for %s %s: %s", method, url, e)
+                if attempt < self.max_retries:
+                    wait_time = 2**attempt
+                    logger.info("Retrying in %ss...", wait_time)
+                    await asyncio.sleep(wait_time)
+                else:
+                    raise ValueError(
+                        f"Request timeout after {self.max_retries} retries"
+                    ) from None
+
+            except httpx.HTTPError as e:
+                logger.error("HTTP error for %s %s: %s", method, url, e)
+                raise ValueError(f"HTTP error: {e}") from None
+
+        raise ValueError("Request failed after all retry attempts")
+
+    async def get(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Make a GET request.
+
+        Args:
+            endpoint: API endpoint.
+            params: Query parameters.
+
+        Returns:
+            Parsed response body.
+
+        """
+        return await self._request("GET", endpoint, params=params)
+
+    async def post(self, endpoint: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Make a POST request.
+
+        Args:
+            endpoint: API endpoint.
+            data: Request body data.
+
+        Returns:
+            Parsed response body.
+
+        """
+        return await self._request("POST", endpoint, json=data)
+
+    async def put(self, endpoint: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Make a PUT request.
+
+        Args:
+            endpoint: API endpoint.
+            data: Request body data.
+
+        Returns:
+            Parsed response body.
+
+        """
+        return await self._request("PUT", endpoint, json=data)
+
+    async def delete(self, endpoint: str) -> dict[str, Any]:
+        """Make a DELETE request.
+
+        Args:
+            endpoint: API endpoint.
+
+        Returns:
+            Parsed response body (often empty for ClickUp deletes).
+
+        """
+        return await self._request("DELETE", endpoint)
+
+    async def test_connection(self) -> bool:
+        """Test API connection and credentials via ``GET /user``.
+
+        Returns:
+            True if the connection succeeds, False otherwise.
+
+        """
+        try:
+            await self.get("/user")
+            return True
+        except Exception as e:
+            # ``e`` is a ValueError raised by _request; it never carries the token.
+            logger.error("ClickUp connection test failed: %s", e)
+            return False
+
+    async def close(self) -> None:
+        """Close the HTTP client and cleanup resources."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None

--- a/src/mcp_ticketer/adapters/clickup/mappers.py
+++ b/src/mcp_ticketer/adapters/clickup/mappers.py
@@ -1,0 +1,275 @@
+"""Data mappers for converting between ClickUp and mcp-ticketer models."""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from ...core.models import (
+    Comment,
+    Epic,
+    Priority,
+    Task,
+    TicketState,
+    TicketType,
+)
+from .types import (
+    map_priority_from_clickup,
+    map_priority_to_clickup,
+    map_status_type_to_state,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def parse_clickup_epoch_ms(value: Any) -> datetime | None:
+    """Parse a ClickUp epoch-milliseconds timestamp to a datetime.
+
+    ClickUp returns timestamps as millisecond epoch strings (e.g. ``"1700000000000"``).
+
+    Args:
+        value: Epoch-milliseconds value as a string, int, or None.
+
+    Returns:
+        Timezone-aware UTC datetime, or None if the value is missing/invalid.
+
+    """
+    if value is None or value == "":
+        return None
+    try:
+        ms = int(value)
+    except (ValueError, TypeError):
+        logger.warning("Failed to parse ClickUp timestamp '%s'", value)
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        logger.warning("ClickUp timestamp out of range '%s'", value)
+        return None
+
+
+def to_clickup_epoch_ms(value: datetime) -> int:
+    """Convert a datetime to ClickUp epoch milliseconds.
+
+    Args:
+        value: A datetime (naive datetimes are treated as UTC).
+
+    Returns:
+        Epoch milliseconds as an int.
+
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return int(value.timestamp() * 1000)
+
+
+def map_clickup_list_to_epic(clickup_list: dict[str, Any]) -> Epic:
+    """Map a ClickUp List to an Epic.
+
+    The Epic/Issue/Task hierarchy maps to ClickUp as:
+    - Epic  -> ClickUp List
+    - Issue -> ClickUp Task (no parent)
+    - Task  -> ClickUp Subtask (has parent)
+
+    Args:
+        clickup_list: ClickUp list object.
+
+    Returns:
+        Epic model instance.
+
+    """
+    # ClickUp lists are archived rather than "closed"; map that to CLOSED.
+    archived = bool(clickup_list.get("archived", False))
+    state = TicketState.CLOSED if archived else TicketState.OPEN
+
+    folder = clickup_list.get("folder") or {}
+    space = clickup_list.get("space") or {}
+
+    return Epic(
+        id=clickup_list.get("id"),
+        title=clickup_list.get("name", ""),
+        description=clickup_list.get("content") or "",
+        state=state,
+        priority=Priority.MEDIUM,
+        created_at=None,
+        updated_at=None,
+        metadata={
+            "clickup_id": clickup_list.get("id"),
+            "clickup_folder_id": folder.get("id"),
+            "clickup_folder_name": folder.get("name"),
+            "clickup_space_id": space.get("id"),
+            "clickup_space_name": space.get("name"),
+            "clickup_archived": archived,
+            "clickup_task_count": clickup_list.get("task_count"),
+        },
+    )
+
+
+def map_clickup_task_to_task(task: dict[str, Any]) -> Task:
+    """Map a ClickUp task to a Task.
+
+    Detects the ticket type from the hierarchy:
+    - Has ``parent`` -> TASK (subtask)
+    - No ``parent``  -> ISSUE (standard task)
+
+    Args:
+        task: ClickUp task object.
+
+    Returns:
+        Task model instance.
+
+    """
+    parent = task.get("parent")
+    ticket_type = TicketType.TASK if parent else TicketType.ISSUE
+
+    # Status is per-list: {"status": "in progress", "type": "custom", ...}.
+    status_obj = task.get("status") or {}
+    status_name = status_obj.get("status") if isinstance(status_obj, dict) else None
+    status_type = status_obj.get("type") if isinstance(status_obj, dict) else None
+    state = map_status_type_to_state(status_type, status_name)
+
+    priority = map_priority_from_clickup(task.get("priority"))
+
+    # Tags are objects: {"name": "bug", "tag_fg": "...", ...}.
+    tags = [
+        t.get("name", "")
+        for t in task.get("tags", [])
+        if isinstance(t, dict) and t.get("name")
+    ]
+
+    # Assignees are objects: take the first one's id as the universal assignee.
+    assignee = None
+    assignees = task.get("assignees", [])
+    if assignees and isinstance(assignees[0], dict):
+        assignee_id = assignees[0].get("id")
+        assignee = str(assignee_id) if assignee_id is not None else None
+
+    # parent_epic (the List) for issues; parent_issue (the task) for subtasks.
+    list_obj = task.get("list") or {}
+    list_id = list_obj.get("id") if isinstance(list_obj, dict) else None
+
+    parent_epic = None
+    parent_issue = None
+    if parent:
+        parent_issue = str(parent)
+    elif list_id:
+        parent_epic = str(list_id)
+
+    # ClickUp returns description as plain "description" and "text_content".
+    description = task.get("description")
+    if description is None:
+        description = task.get("text_content") or ""
+
+    return Task(
+        id=task.get("id"),
+        title=task.get("name", ""),
+        description=description,
+        state=state,
+        priority=priority,
+        tags=tags,
+        assignee=assignee,
+        ticket_type=ticket_type,
+        parent_epic=parent_epic,
+        parent_issue=parent_issue,
+        created_at=parse_clickup_epoch_ms(task.get("date_created")),
+        updated_at=parse_clickup_epoch_ms(task.get("date_updated")),
+        metadata={
+            "clickup_id": task.get("id"),
+            "clickup_url": task.get("url"),
+            "clickup_list_id": list_id,
+            "clickup_folder_id": (task.get("folder") or {}).get("id"),
+            "clickup_space_id": (task.get("space") or {}).get("id"),
+            "clickup_status_name": status_name,
+            "clickup_status_type": status_type,
+            "clickup_due_date": task.get("due_date"),
+            "clickup_start_date": task.get("start_date"),
+            "clickup_date_closed": task.get("date_closed"),
+            "clickup_assignee_ids": [
+                a.get("id") for a in assignees if isinstance(a, dict)
+            ],
+            "clickup_parent": parent,
+        },
+    )
+
+
+def map_task_to_clickup_payload(task: Task) -> dict[str, Any]:
+    """Map a Task to a ClickUp task create payload.
+
+    Status is intentionally NOT included here: ClickUp statuses are per-list and
+    must be resolved against the target list's statuses by the adapter before
+    being added to the payload.
+
+    Args:
+        task: Task model instance.
+
+    Returns:
+        ClickUp task create payload.
+
+    """
+    payload: dict[str, Any] = {"name": task.title}
+
+    if task.description:
+        payload["description"] = task.description
+
+    payload["priority"] = map_priority_to_clickup(task.priority)
+
+    if task.tags:
+        payload["tags"] = list(task.tags)
+
+    # Subtask linkage: ClickUp uses "parent" = parent task id.
+    if task.parent_issue:
+        payload["parent"] = task.parent_issue
+
+    # Due date if the caller stashed an epoch-ms value in metadata.
+    due_date = task.metadata.get("clickup_due_date")
+    if due_date is not None:
+        payload["due_date"] = due_date
+
+    return payload
+
+
+def map_clickup_comment_to_comment(comment: dict[str, Any], task_id: str) -> Comment:
+    """Map a ClickUp comment to a Comment.
+
+    ClickUp comments are shaped::
+
+        {
+          "id": "...",
+          "comment_text": "Hello",
+          "user": {"id": 123, "username": "Jane"},
+          "date": "1700000000000"
+        }
+
+    Args:
+        comment: ClickUp comment object.
+        task_id: Parent task id.
+
+    Returns:
+        Comment model instance.
+
+    """
+    user = comment.get("user") or {}
+    author_id = user.get("id")
+    author = str(author_id) if author_id is not None else user.get("username")
+
+    # ClickUp returns either "comment_text" (string) or "comment" (rich blocks).
+    content = comment.get("comment_text")
+    if not content:
+        blocks = comment.get("comment")
+        if isinstance(blocks, list):
+            content = "".join(b.get("text", "") for b in blocks if isinstance(b, dict))
+    if not content:
+        # Comment.content has min_length=1; never emit an empty string.
+        content = " "
+
+    return Comment(
+        id=str(comment.get("id")) if comment.get("id") is not None else None,
+        ticket_id=task_id,
+        author=author,
+        content=content,
+        created_at=parse_clickup_epoch_ms(comment.get("date")),
+        metadata={
+            "clickup_id": comment.get("id"),
+            "clickup_username": user.get("username"),
+            "clickup_resolved": comment.get("resolved"),
+        },
+    )

--- a/src/mcp_ticketer/adapters/clickup/types.py
+++ b/src/mcp_ticketer/adapters/clickup/types.py
@@ -1,0 +1,251 @@
+"""ClickUp-specific types, constants, and state mappings."""
+
+from ...core.models import Priority, TicketState
+
+# ClickUp API v2 base URL.
+CLICKUP_BASE_URL = "https://api.clickup.com/api/v2"
+
+# ClickUp priority is a small integer: 1=urgent, 2=high, 3=normal, 4=low, None=none.
+# These map to/from the universal Priority enum.
+PRIORITY_URGENT = 1
+PRIORITY_HIGH = 2
+PRIORITY_NORMAL = 3
+PRIORITY_LOW = 4
+
+
+class ClickUpStatusType:
+    """ClickUp status "type" values returned by GET /list/{id}.
+
+    Each ClickUp list defines its own ordered set of statuses. Every status has
+    a ``type`` field that ClickUp guarantees across all lists, which lets us map
+    arbitrary per-list status names back to a universal ``TicketState``:
+
+    - ``open``: the not-started "to do" column (one per list).
+    - ``custom``: any user-defined in-flight column (e.g. "in progress", "review").
+    - ``done``: a completed-but-not-archived column.
+    - ``closed``: the terminal "closed" column (one per list).
+    """
+
+    OPEN = "open"
+    CUSTOM = "custom"
+    DONE = "done"
+    CLOSED = "closed"
+
+
+class ClickUpPriorityMapping:
+    """Mapping between universal Priority and ClickUp integer priority codes.
+
+    ClickUp uses a fixed integer scale, unlike the per-list status names.
+    """
+
+    TO_CLICKUP = {
+        Priority.LOW: PRIORITY_LOW,
+        Priority.MEDIUM: PRIORITY_NORMAL,
+        Priority.HIGH: PRIORITY_HIGH,
+        Priority.CRITICAL: PRIORITY_URGENT,
+    }
+
+    FROM_CLICKUP = {
+        PRIORITY_URGENT: Priority.CRITICAL,
+        PRIORITY_HIGH: Priority.HIGH,
+        PRIORITY_NORMAL: Priority.MEDIUM,
+        PRIORITY_LOW: Priority.LOW,
+    }
+
+
+# Keyword buckets for resolving a universal TicketState to a per-list status NAME
+# when the status "type" alone is not granular enough (ClickUp collapses every
+# user-defined in-flight column under the single "custom" type). Ordered so the
+# first matching keyword wins.
+STATE_NAME_KEYWORDS: dict[TicketState, list[str]] = {
+    TicketState.OPEN: ["to do", "todo", "open", "backlog", "not started", "new"],
+    TicketState.IN_PROGRESS: [
+        "in progress",
+        "in-progress",
+        "working",
+        "started",
+        "doing",
+    ],
+    TicketState.READY: ["ready", "ready for review", "review", "in review"],
+    TicketState.TESTED: ["tested", "qa", "verified", "testing"],
+    TicketState.DONE: ["done", "complete", "completed", "finished"],
+    TicketState.WAITING: ["waiting", "on hold", "hold", "pending"],
+    TicketState.BLOCKED: ["blocked", "stuck", "at risk"],
+    TicketState.CLOSED: ["closed", "archived", "cancelled", "canceled"],
+}
+
+
+def map_priority_to_clickup(priority: Priority) -> int:
+    """Map a universal priority to a ClickUp integer priority code.
+
+    Args:
+        priority: Universal priority level.
+
+    Returns:
+        ClickUp integer priority (1=urgent, 2=high, 3=normal, 4=low).
+
+    """
+    return ClickUpPriorityMapping.TO_CLICKUP.get(priority, PRIORITY_NORMAL)
+
+
+def map_priority_from_clickup(clickup_priority: object) -> Priority:
+    """Map a ClickUp priority value to a universal priority.
+
+    ClickUp returns priority either as ``None`` (no priority) or as an object
+    ``{"id": "1", "priority": "urgent", "orderindex": "1"}``. This helper
+    accepts the raw value, an int, a numeric string, or the embedded object.
+
+    Args:
+        clickup_priority: Raw ClickUp priority value (None, int, str, or dict).
+
+    Returns:
+        Universal priority level (defaults to MEDIUM when absent/unknown).
+
+    """
+    if clickup_priority is None:
+        return Priority.MEDIUM
+
+    code: int | None = None
+
+    if isinstance(clickup_priority, dict):
+        # ClickUp embeds priority as {"id": "1", "priority": "urgent", ...}.
+        raw_id = clickup_priority.get("id")
+        if raw_id is not None:
+            try:
+                code = int(raw_id)
+            except (ValueError, TypeError):
+                code = None
+        if code is None:
+            name = str(clickup_priority.get("priority", "")).lower()
+            name_to_code = {
+                "urgent": PRIORITY_URGENT,
+                "high": PRIORITY_HIGH,
+                "normal": PRIORITY_NORMAL,
+                "low": PRIORITY_LOW,
+            }
+            code = name_to_code.get(name)
+    elif isinstance(clickup_priority, int):
+        code = clickup_priority
+    elif isinstance(clickup_priority, str):
+        try:
+            code = int(clickup_priority)
+        except ValueError:
+            code = None
+
+    if code is None:
+        return Priority.MEDIUM
+
+    return ClickUpPriorityMapping.FROM_CLICKUP.get(code, Priority.MEDIUM)
+
+
+def map_status_type_to_state(
+    status_type: str | None, status_name: str | None
+) -> TicketState:
+    """Map a ClickUp status (type + name) to a universal TicketState.
+
+    Resolution order:
+    1. ``type == "open"``  -> OPEN
+    2. ``type == "closed"`` -> CLOSED
+    3. ``type == "done"``  -> DONE
+    4. ``type == "custom"`` -> resolve by name keywords (in_progress/ready/...).
+       Falls back to IN_PROGRESS for unrecognised custom columns, since a custom
+       column is by definition an active, non-terminal stage.
+
+    Args:
+        status_type: ClickUp status ``type`` field ("open"/"custom"/"done"/"closed").
+        status_name: ClickUp status display name (per-list, e.g. "in review").
+
+    Returns:
+        Universal ticket state.
+
+    """
+    stype = (status_type or "").lower()
+
+    if stype == ClickUpStatusType.OPEN:
+        return TicketState.OPEN
+    if stype == ClickUpStatusType.CLOSED:
+        return TicketState.CLOSED
+    if stype == ClickUpStatusType.DONE:
+        return TicketState.DONE
+
+    # type == "custom" (or unknown): disambiguate by the display name.
+    name_lower = (status_name or "").lower().strip()
+    if name_lower:
+        for state, keywords in STATE_NAME_KEYWORDS.items():
+            for keyword in keywords:
+                if keyword in name_lower:
+                    return state
+
+    # A custom column with no recognisable name is an active stage.
+    return TicketState.IN_PROGRESS
+
+
+def resolve_state_to_status_name(
+    state: TicketState, available_statuses: list[dict[str, object]]
+) -> str | None:
+    """Resolve a universal TicketState to a concrete per-list status NAME.
+
+    Because ClickUp statuses are per-list, the adapter must pick a status name
+    that actually exists in the target list. Strategy:
+
+    1. Prefer a status whose ``type`` matches the state's category
+       (OPEN->open, DONE->done, CLOSED->closed).
+    2. For in-flight states, prefer a status whose name contains one of the
+       state's keywords.
+    3. Fall back to the first ``done``/``closed`` status for terminal states, or
+       the first ``open`` status otherwise.
+
+    Args:
+        state: Universal ticket state to resolve.
+        available_statuses: List of ClickUp status objects from GET /list/{id},
+            each shaped ``{"status": "in progress", "type": "custom", ...}``.
+
+    Returns:
+        A matching ClickUp status name, or None if the list has no statuses.
+
+    """
+    if not available_statuses:
+        return None
+
+    def status_name(s: dict[str, object]) -> str:
+        return str(s.get("status", ""))
+
+    def status_type(s: dict[str, object]) -> str:
+        return str(s.get("type", "")).lower()
+
+    # 1. Type-category match for terminal/initial states.
+    if state == TicketState.OPEN:
+        for s in available_statuses:
+            if status_type(s) == ClickUpStatusType.OPEN:
+                return status_name(s)
+    elif state == TicketState.DONE:
+        for s in available_statuses:
+            if status_type(s) == ClickUpStatusType.DONE:
+                return status_name(s)
+    elif state == TicketState.CLOSED:
+        for s in available_statuses:
+            if status_type(s) == ClickUpStatusType.CLOSED:
+                return status_name(s)
+
+    # 2. Keyword match against status names (handles in_progress/ready/etc.).
+    keywords = STATE_NAME_KEYWORDS.get(state, [])
+    for keyword in keywords:
+        for s in available_statuses:
+            if keyword in status_name(s).lower():
+                return status_name(s)
+
+    # 3. Sensible fallbacks by completion category.
+    if state in (TicketState.DONE, TicketState.TESTED):
+        for s in available_statuses:
+            if status_type(s) == ClickUpStatusType.DONE:
+                return status_name(s)
+    if state == TicketState.CLOSED:
+        for s in available_statuses:
+            if status_type(s) == ClickUpStatusType.CLOSED:
+                return status_name(s)
+
+    # Default: the list's "open" status if present, else the first status.
+    for s in available_statuses:
+        if status_type(s) == ClickUpStatusType.OPEN:
+            return status_name(s)
+    return status_name(available_statuses[0])

--- a/src/mcp_ticketer/core/env_discovery.py
+++ b/src/mcp_ticketer/core/env_discovery.py
@@ -103,6 +103,35 @@ AITRACKDOWN_PATH_PATTERNS = [
     "MCP_TICKETER_AITRACKDOWN_BASE_PATH",
 ]
 
+CLICKUP_TOKEN_PATTERNS = [
+    "CLICKUP_API_TOKEN",
+    "CLICKUP_TOKEN",
+    "CLICKUP_API_KEY",
+    "CLICKUP_KEY",
+    "MCP_TICKETER_CLICKUP_API_TOKEN",
+]
+
+CLICKUP_TEAM_PATTERNS = [
+    "CLICKUP_TEAM_ID",
+    "CLICKUP_WORKSPACE_ID",
+    "MCP_TICKETER_CLICKUP_TEAM_ID",
+]
+
+CLICKUP_LIST_PATTERNS = [
+    "CLICKUP_LIST_ID",
+    "MCP_TICKETER_CLICKUP_LIST_ID",
+]
+
+CLICKUP_SPACE_PATTERNS = [
+    "CLICKUP_SPACE_ID",
+    "MCP_TICKETER_CLICKUP_SPACE_ID",
+]
+
+CLICKUP_FOLDER_PATTERNS = [
+    "CLICKUP_FOLDER_ID",
+    "MCP_TICKETER_CLICKUP_FOLDER_ID",
+]
+
 
 @dataclass
 class DiscoveredAdapter:
@@ -213,6 +242,12 @@ class EnvDiscovery:
         )
         if jira_adapter:
             result.adapters.append(jira_adapter)
+
+        clickup_adapter = self._detect_clickup(
+            env_vars, result.env_files_found[0] if result.env_files_found else ".env"
+        )
+        if clickup_adapter:
+            result.adapters.append(clickup_adapter)
 
         aitrackdown_adapter = self._detect_aitrackdown(
             env_vars, result.env_files_found[0] if result.env_files_found else ".env"
@@ -470,6 +505,65 @@ class EnvDiscovery:
             found_in=found_in,
         )
 
+    def _detect_clickup(
+        self, env_vars: dict[str, str], found_in: str
+    ) -> DiscoveredAdapter | None:
+        """Detect ClickUp adapter configuration.
+
+        Args:
+            env_vars: Environment variables.
+            found_in: Which file the config was found in.
+
+        Returns:
+            DiscoveredAdapter if ClickUp config detected, None otherwise.
+
+        """
+        api_token = self._find_key_value(env_vars, CLICKUP_TOKEN_PATTERNS)
+
+        if not api_token:
+            return None
+
+        config: dict[str, Any] = {
+            "api_token": api_token,
+            "adapter": "clickup",
+        }
+
+        missing_fields: list[str] = []
+        confidence = 0.5  # Has token
+
+        # Team (workspace) id (recommended for create/list operations).
+        team_id = self._find_key_value(env_vars, CLICKUP_TEAM_PATTERNS)
+        if team_id:
+            config["team_id"] = team_id
+            confidence += 0.2
+        else:
+            missing_fields.append("team_id (recommended)")
+
+        # Default list id for task creation (optional but commonly needed).
+        list_id = self._find_key_value(env_vars, CLICKUP_LIST_PATTERNS)
+        if list_id:
+            config["list_id"] = list_id
+            confidence += 0.2
+
+        # Optional space / folder scoping.
+        space_id = self._find_key_value(env_vars, CLICKUP_SPACE_PATTERNS)
+        if space_id:
+            config["space_id"] = space_id
+            confidence += 0.05
+
+        folder_id = self._find_key_value(env_vars, CLICKUP_FOLDER_PATTERNS)
+        if folder_id:
+            config["folder_id"] = folder_id
+            confidence += 0.05
+
+        return DiscoveredAdapter(
+            adapter_type="clickup",
+            config=config,
+            confidence=min(confidence, 1.0),
+            missing_fields=missing_fields,
+            found_in=found_in,
+        )
+
     def _detect_aitrackdown(
         self, env_vars: dict[str, str], found_in: str
     ) -> DiscoveredAdapter | None:
@@ -501,6 +595,7 @@ class EnvDiscovery:
             any(key.startswith("LINEAR_") for key in env_vars)
             or any(key.startswith("GITHUB_") for key in env_vars)
             or any(key.startswith("JIRA_") for key in env_vars)
+            or any(key.startswith("CLICKUP_") for key in env_vars)
         )
 
         if not base_path and not aitrackdown_dir.exists():

--- a/tests/adapters/test_clickup_adapter.py
+++ b/tests/adapters/test_clickup_adapter.py
@@ -1,0 +1,746 @@
+"""Mocked-HTTP unit tests for the ClickUp adapter.
+
+All ClickUp REST calls are mocked at the ``ClickUpClient`` method level
+(``get``/``post``/``put``/``delete``) so the suite runs with no network access
+and no real ClickUp token. This mirrors the JIRA adapter's mocking approach in
+``tests/adapters/test_jira_new_methods.py``.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from mcp_ticketer.adapters.clickup import ClickUpAdapter
+from mcp_ticketer.adapters.clickup.client import ClickUpClient
+from mcp_ticketer.adapters.clickup.mappers import (
+    map_clickup_comment_to_comment,
+    map_clickup_list_to_epic,
+    map_clickup_task_to_task,
+    parse_clickup_epoch_ms,
+    to_clickup_epoch_ms,
+)
+from mcp_ticketer.adapters.clickup.types import (
+    map_priority_from_clickup,
+    map_priority_to_clickup,
+    map_status_type_to_state,
+    resolve_state_to_status_name,
+)
+from mcp_ticketer.core.models import (
+    Comment,
+    Epic,
+    Priority,
+    SearchQuery,
+    Task,
+    TicketState,
+    TicketType,
+)
+from mcp_ticketer.core.registry import AdapterRegistry
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clickup_config():
+    """Standard ClickUp configuration for testing."""
+    return {
+        "api_token": "pk_test_TOKEN_123",
+        "team_id": "9007001",
+        "list_id": "901000123",
+        "space_id": "90120001",
+        "folder_id": "90130002",
+    }
+
+
+@pytest.fixture
+def adapter(clickup_config):
+    """Create a ClickUp adapter that is already 'initialized' (no network)."""
+    a = ClickUpAdapter(clickup_config)
+    # Pretend initialize() already ran so methods don't try to test_connection.
+    a._initialized = True
+    return a
+
+
+# Sample ClickUp API objects -------------------------------------------------
+
+LIST_STATUSES = [
+    {"status": "to do", "type": "open", "orderindex": 0},
+    {"status": "in progress", "type": "custom", "orderindex": 1},
+    {"status": "in review", "type": "custom", "orderindex": 2},
+    {"status": "complete", "type": "done", "orderindex": 3},
+    {"status": "closed", "type": "closed", "orderindex": 4},
+]
+
+
+def make_task_obj(**overrides):
+    """Build a representative ClickUp task object."""
+    obj = {
+        "id": "task_abc",
+        "name": "Fix login bug",
+        "description": "Users cannot log in",
+        "status": {"status": "in progress", "type": "custom"},
+        "priority": {"id": "2", "priority": "high"},
+        "tags": [{"name": "bug"}, {"name": "auth"}],
+        "assignees": [{"id": 42, "username": "jane"}],
+        "list": {"id": "901000123", "name": "Sprint 1"},
+        "folder": {"id": "90130002"},
+        "space": {"id": "90120001"},
+        "parent": None,
+        "date_created": "1700000000000",
+        "date_updated": "1700000100000",
+        "url": "https://app.clickup.com/t/task_abc",
+    }
+    obj.update(overrides)
+    return obj
+
+
+# --------------------------------------------------------------------------
+# Registration & credentials
+# --------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """Adapter registration in the global registry."""
+
+    def test_clickup_registered(self):
+        """ClickUp adapter is registered under the 'clickup' name."""
+        assert AdapterRegistry.is_registered("clickup")
+
+    def test_registry_returns_clickup_class(self):
+        """The registry maps 'clickup' to ClickUpAdapter."""
+        assert AdapterRegistry.list_adapters()["clickup"] is ClickUpAdapter
+
+    def test_adapter_type_property(self, adapter):
+        """adapter_type derives 'clickup' from the class name."""
+        assert adapter.adapter_type == "clickup"
+
+
+class TestCredentials:
+    """Credential handling and token sourcing."""
+
+    def test_missing_token_raises(self, monkeypatch):
+        """Constructing without a token raises ValueError."""
+        monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+        monkeypatch.delenv("MCP_TICKETER_CLICKUP_API_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="ClickUp API token is required"):
+            ClickUpAdapter({})
+
+    def test_token_from_env(self, monkeypatch):
+        """Token is read from CLICKUP_API_TOKEN when not in config."""
+        monkeypatch.setenv("CLICKUP_API_TOKEN", "pk_env_TOKEN")
+        a = ClickUpAdapter({})
+        assert a.api_token == "pk_env_TOKEN"
+
+    def test_token_prefix_stripped(self):
+        """An accidental NAME=value prefix on the token is stripped."""
+        a = ClickUpAdapter({"api_token": "CLICKUP_API_TOKEN=pk_real"})
+        assert a.api_token == "pk_real"
+
+    def test_validate_credentials_ok(self, adapter):
+        """validate_credentials returns (True, '') with a token present."""
+        is_valid, msg = adapter.validate_credentials()
+        assert is_valid is True
+        assert msg == ""
+
+    def test_config_overrides_env(self, monkeypatch):
+        """Config team/list win over environment variables."""
+        monkeypatch.setenv("CLICKUP_TEAM_ID", "env_team")
+        monkeypatch.setenv("CLICKUP_LIST_ID", "env_list")
+        a = ClickUpAdapter(
+            {"api_token": "pk_x", "team_id": "cfg_team", "list_id": "cfg_list"}
+        )
+        assert a._team_id == "cfg_team"
+        assert a._default_list_id == "cfg_list"
+
+
+# --------------------------------------------------------------------------
+# Pure mapping helpers (no I/O)
+# --------------------------------------------------------------------------
+
+
+class TestPriorityMapping:
+    """Priority conversions between universal and ClickUp."""
+
+    @pytest.mark.parametrize(
+        "priority,code",
+        [
+            (Priority.CRITICAL, 1),
+            (Priority.HIGH, 2),
+            (Priority.MEDIUM, 3),
+            (Priority.LOW, 4),
+        ],
+    )
+    def test_to_clickup(self, priority, code):
+        """Each universal priority maps to its ClickUp integer code."""
+        assert map_priority_to_clickup(priority) == code
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, Priority.MEDIUM),
+            (1, Priority.CRITICAL),
+            ("2", Priority.HIGH),
+            ({"id": "4", "priority": "low"}, Priority.LOW),
+            ({"priority": "urgent"}, Priority.CRITICAL),
+            ("garbage", Priority.MEDIUM),
+        ],
+    )
+    def test_from_clickup(self, value, expected):
+        """ClickUp priority values map back to universal priorities."""
+        assert map_priority_from_clickup(value) == expected
+
+
+class TestStatusMapping:
+    """Per-list status <-> universal state mapping (the core mapping work)."""
+
+    @pytest.mark.parametrize(
+        "stype,name,expected",
+        [
+            ("open", "to do", TicketState.OPEN),
+            ("closed", "closed", TicketState.CLOSED),
+            ("done", "complete", TicketState.DONE),
+            ("custom", "in progress", TicketState.IN_PROGRESS),
+            ("custom", "in review", TicketState.READY),
+            ("custom", "QA testing", TicketState.TESTED),
+            ("custom", "blocked", TicketState.BLOCKED),
+            ("custom", "waiting", TicketState.WAITING),
+            ("custom", "something weird", TicketState.IN_PROGRESS),
+        ],
+    )
+    def test_status_type_to_state(self, stype, name, expected):
+        """Status type+name resolves to the right universal state."""
+        assert map_status_type_to_state(stype, name) == expected
+
+    def test_resolve_state_open(self):
+        """OPEN resolves to the list's 'open'-type status name."""
+        assert resolve_state_to_status_name(TicketState.OPEN, LIST_STATUSES) == "to do"
+
+    def test_resolve_state_done(self):
+        """DONE resolves to the list's 'done'-type status name."""
+        assert (
+            resolve_state_to_status_name(TicketState.DONE, LIST_STATUSES) == "complete"
+        )
+
+    def test_resolve_state_closed(self):
+        """CLOSED resolves to the list's 'closed'-type status name."""
+        assert (
+            resolve_state_to_status_name(TicketState.CLOSED, LIST_STATUSES) == "closed"
+        )
+
+    def test_resolve_state_in_progress_by_keyword(self):
+        """IN_PROGRESS resolves to a custom column whose name matches a keyword."""
+        assert (
+            resolve_state_to_status_name(TicketState.IN_PROGRESS, LIST_STATUSES)
+            == "in progress"
+        )
+
+    def test_resolve_state_ready_by_keyword(self):
+        """READY resolves to the 'in review' custom column."""
+        assert (
+            resolve_state_to_status_name(TicketState.READY, LIST_STATUSES)
+            == "in review"
+        )
+
+    def test_resolve_state_empty_list(self):
+        """Resolving against an empty status list returns None."""
+        assert resolve_state_to_status_name(TicketState.OPEN, []) is None
+
+
+class TestTimestampMapping:
+    """Epoch-millisecond conversions."""
+
+    def test_parse_epoch_ms(self):
+        """A millisecond epoch string parses to a UTC datetime."""
+        dt = parse_clickup_epoch_ms("1700000000000")
+        assert dt is not None
+        assert dt.year == 2023
+
+    def test_parse_epoch_ms_none(self):
+        """None/empty input parses to None."""
+        assert parse_clickup_epoch_ms(None) is None
+        assert parse_clickup_epoch_ms("") is None
+
+    def test_parse_epoch_ms_invalid(self):
+        """A non-numeric value parses to None (not an exception)."""
+        assert parse_clickup_epoch_ms("not-a-number") is None
+
+    def test_round_trip(self):
+        """to_clickup_epoch_ms inverts parse_clickup_epoch_ms (to the second)."""
+        dt = parse_clickup_epoch_ms("1700000000000")
+        assert to_clickup_epoch_ms(dt) == 1700000000000
+
+
+class TestObjectMappers:
+    """ClickUp object -> universal model mappers."""
+
+    def test_map_task_issue(self):
+        """A parent-less ClickUp task maps to an ISSUE Task with full fields."""
+        task = map_clickup_task_to_task(make_task_obj())
+        assert isinstance(task, Task)
+        assert task.id == "task_abc"
+        assert task.title == "Fix login bug"
+        assert task.ticket_type == TicketType.ISSUE
+        assert task.state == TicketState.IN_PROGRESS
+        assert task.priority == Priority.HIGH
+        assert task.tags == ["bug", "auth"]
+        assert task.assignee == "42"
+        assert task.parent_epic == "901000123"
+        assert task.parent_issue is None
+
+    def test_map_task_subtask(self):
+        """A ClickUp task with a parent maps to a TASK (subtask)."""
+        obj = make_task_obj(parent="task_parent")
+        task = map_clickup_task_to_task(obj)
+        assert task.ticket_type == TicketType.TASK
+        assert task.parent_issue == "task_parent"
+        assert task.parent_epic is None
+
+    def test_map_list_to_epic(self):
+        """A ClickUp list maps to an Epic."""
+        epic = map_clickup_list_to_epic(
+            {
+                "id": "901000123",
+                "name": "Sprint 1",
+                "content": "Backlog list",
+                "archived": False,
+                "folder": {"id": "90130002", "name": "F"},
+                "space": {"id": "90120001", "name": "S"},
+            }
+        )
+        assert isinstance(epic, Epic)
+        assert epic.id == "901000123"
+        assert epic.title == "Sprint 1"
+        assert epic.state == TicketState.OPEN
+        assert epic.metadata["clickup_folder_id"] == "90130002"
+
+    def test_map_archived_list_is_closed(self):
+        """An archived list maps to CLOSED state."""
+        epic = map_clickup_list_to_epic({"id": "1", "name": "X", "archived": True})
+        assert epic.state == TicketState.CLOSED
+
+    def test_map_comment(self):
+        """A ClickUp comment maps to a Comment."""
+        comment = map_clickup_comment_to_comment(
+            {
+                "id": "c1",
+                "comment_text": "Looks good",
+                "user": {"id": 7, "username": "bob"},
+                "date": "1700000000000",
+            },
+            "task_abc",
+        )
+        assert isinstance(comment, Comment)
+        assert comment.content == "Looks good"
+        assert comment.author == "7"
+        assert comment.ticket_id == "task_abc"
+
+    def test_map_comment_rich_blocks(self):
+        """A ClickUp comment with rich blocks is flattened to text."""
+        comment = map_clickup_comment_to_comment(
+            {
+                "id": "c2",
+                "comment": [{"text": "Hello "}, {"text": "world"}],
+                "user": {"id": 7, "username": "bob"},
+            },
+            "task_abc",
+        )
+        assert comment.content == "Hello world"
+
+    def test_map_comment_empty_never_violates_min_length(self):
+        """An empty comment body becomes a single space (min_length=1 guard)."""
+        comment = map_clickup_comment_to_comment(
+            {"id": "c3", "user": {"id": 7}}, "task_abc"
+        )
+        assert comment.content == " "
+
+
+# --------------------------------------------------------------------------
+# CRUD operations (mocked client)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCreate:
+    """create() for tasks and epics."""
+
+    async def test_create_issue(self, adapter):
+        """Creating an issue posts to /list/{id}/task and resolves status."""
+        created_resp = {"id": "task_new"}
+        full_task = make_task_obj(id="task_new", name="New issue")
+
+        with (
+            patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get,
+            patch.object(adapter.client, "post", new_callable=AsyncMock) as mock_post,
+        ):
+            # get() is called for: list statuses (status resolution) + full read.
+            mock_get.side_effect = [
+                {"statuses": LIST_STATUSES},  # _get_list_statuses
+                full_task,  # re-read after create
+            ]
+            mock_post.return_value = created_resp
+
+            task = Task(
+                title="New issue",
+                ticket_type=TicketType.ISSUE,
+                parent_epic="901000123",
+                state=TicketState.IN_PROGRESS,
+                priority=Priority.HIGH,
+            )
+            result = await adapter.create(task)
+
+            assert result.id == "task_new"
+            # POST went to the list task endpoint.
+            post_endpoint = mock_post.call_args.args[0]
+            assert post_endpoint == "/list/901000123/task"
+            # Payload carried a resolved per-list status name + integer priority.
+            payload = mock_post.call_args.args[1]
+            assert payload["status"] == "in progress"
+            assert payload["priority"] == 2
+            assert payload["name"] == "New issue"
+
+    async def test_create_subtask_sets_parent(self, adapter):
+        """Creating a subtask passes the parent task id in the payload."""
+        with (
+            patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get,
+            patch.object(adapter.client, "post", new_callable=AsyncMock) as mock_post,
+        ):
+            # Default state is OPEN, so no status resolution get() — the only
+            # get() is the post-create re-read.
+            mock_get.return_value = make_task_obj(id="sub1", parent="task_parent")
+            mock_post.return_value = {"id": "sub1"}
+
+            task = Task(
+                title="A subtask",
+                ticket_type=TicketType.TASK,
+                parent_issue="task_parent",
+            )
+            result = await adapter.create(task)
+
+            assert result.ticket_type == TicketType.TASK
+            payload = mock_post.call_args.args[1]
+            assert payload["parent"] == "task_parent"
+
+    async def test_create_task_without_list_raises(self, adapter):
+        """Creating a task with no parent_epic and no default list raises."""
+        adapter._default_list_id = None
+        task = Task(title="Orphan", ticket_type=TicketType.ISSUE)
+        with pytest.raises(ValueError, match="requires a target list"):
+            await adapter.create(task)
+
+    async def test_create_epic_in_folder(self, adapter):
+        """Creating an epic posts to the configured folder list endpoint."""
+        with patch.object(adapter.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"id": "list_new", "name": "Epic A"}
+            epic = Epic(title="Epic A", description="desc")
+            result = await adapter.create(epic)
+            assert isinstance(result, Epic)
+            assert result.id == "list_new"
+            assert mock_post.call_args.args[0] == "/folder/90130002/list"
+
+    async def test_create_epic_without_scope_raises(self, adapter):
+        """Creating an epic with no folder/space configured raises."""
+        adapter._folder_id = None
+        adapter._space_id = None
+        with pytest.raises(ValueError, match="folder_id .* or space_id"):
+            await adapter.create(Epic(title="Epic B"))
+
+
+@pytest.mark.asyncio
+class TestReadUpdateDelete:
+    """read / update / delete / transition_state."""
+
+    async def test_read_found(self, adapter):
+        """read() returns a mapped Task."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = make_task_obj()
+            task = await adapter.read("task_abc")
+            assert task is not None
+            assert task.title == "Fix login bug"
+            assert mock_get.call_args.args[0] == "/task/task_abc"
+
+    async def test_read_not_found_returns_none(self, adapter):
+        """read() returns None when the client raises (e.g. 404)."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = ValueError("ClickUp API error (404): not found")
+            assert await adapter.read("missing") is None
+
+    async def test_update_title_and_priority(self, adapter):
+        """update() puts name/priority and re-reads the task."""
+        with (
+            patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get,
+            patch.object(adapter.client, "put", new_callable=AsyncMock) as mock_put,
+        ):
+            mock_get.return_value = make_task_obj(name="Updated")
+            mock_put.return_value = {}
+
+            result = await adapter.update(
+                "task_abc", {"title": "Updated", "priority": Priority.CRITICAL}
+            )
+            assert result.title == "Updated"
+            payload = mock_put.call_args.args[1]
+            assert payload["name"] == "Updated"
+            assert payload["priority"] == 1
+
+    async def test_update_state_resolves_status(self, adapter):
+        """update(state=...) looks up the task's list then resolves the status."""
+        with (
+            patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get,
+            patch.object(adapter.client, "put", new_callable=AsyncMock) as mock_put,
+        ):
+            # get() calls: _task_list_id, _get_list_statuses, final re-read.
+            mock_get.side_effect = [
+                {"list": {"id": "901000123"}},
+                {"statuses": LIST_STATUSES},
+                make_task_obj(status={"status": "complete", "type": "done"}),
+            ]
+            mock_put.return_value = {}
+
+            result = await adapter.update("task_abc", {"state": TicketState.DONE})
+            assert result.state == TicketState.DONE
+            payload = mock_put.call_args.args[1]
+            assert payload["status"] == "complete"
+
+    async def test_delete_success(self, adapter):
+        """delete() returns True on success."""
+        with patch.object(adapter.client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = {}
+            assert await adapter.delete("task_abc") is True
+            assert mock_del.call_args.args[0] == "/task/task_abc"
+
+    async def test_delete_failure_returns_false(self, adapter):
+        """delete() returns False when the client raises."""
+        with patch.object(adapter.client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.side_effect = ValueError("boom")
+            assert await adapter.delete("task_abc") is False
+
+    async def test_transition_state_delegates_to_update(self, adapter):
+        """transition_state() routes through update()."""
+        with patch.object(adapter, "update", new_callable=AsyncMock) as mock_update:
+            mock_update.return_value = None
+            await adapter.transition_state("task_abc", TicketState.READY)
+            mock_update.assert_called_once_with(
+                "task_abc", {"state": TicketState.READY}
+            )
+
+
+@pytest.mark.asyncio
+class TestListAndSearch:
+    """list() and search()."""
+
+    async def test_list_by_epic(self, adapter):
+        """list() fetches tasks from the list endpoint and maps them."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "tasks": [make_task_obj(id="t1"), make_task_obj(id="t2")]
+            }
+            tasks = await adapter.list(filters={"parent_epic": "901000123"})
+            assert len(tasks) == 2
+            assert mock_get.call_args.args[0] == "/list/901000123/task"
+
+    async def test_list_state_filter(self, adapter):
+        """list() applies a client-side state filter."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "tasks": [
+                    make_task_obj(id="t1", status={"status": "to do", "type": "open"}),
+                    make_task_obj(
+                        id="t2", status={"status": "complete", "type": "done"}
+                    ),
+                ]
+            }
+            tasks = await adapter.list(
+                filters={"parent_epic": "901000123", "state": TicketState.DONE}
+            )
+            assert [t.id for t in tasks] == ["t2"]
+
+    async def test_list_no_list_id_returns_empty(self, adapter):
+        """list() with no resolvable list returns an empty list."""
+        adapter._default_list_id = None
+        assert await adapter.list() == []
+
+    async def test_search_text_filter(self, adapter):
+        """search() filters by title text on top of list()."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "tasks": [
+                    make_task_obj(id="t1", name="login bug"),
+                    make_task_obj(id="t2", name="dashboard work"),
+                ]
+            }
+            results = await adapter.search(
+                SearchQuery(query="login", project="901000123")
+            )
+            assert [t.id for t in results] == ["t1"]
+
+
+@pytest.mark.asyncio
+class TestComments:
+    """add_comment / get_comments."""
+
+    async def test_add_comment(self, adapter):
+        """add_comment posts comment_text and returns a Comment."""
+        with patch.object(adapter.client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"id": "c99", "date": "1700000000000"}
+            result = await adapter.add_comment(
+                Comment(ticket_id="task_abc", content="Nice work")
+            )
+            assert result.content == "Nice work"
+            assert mock_post.call_args.args[0] == "/task/task_abc/comment"
+            assert mock_post.call_args.args[1] == {"comment_text": "Nice work"}
+
+    async def test_get_comments(self, adapter):
+        """get_comments returns mapped comments with offset/limit applied."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "comments": [
+                    {"id": "c1", "comment_text": "a", "user": {"id": 1}},
+                    {"id": "c2", "comment_text": "b", "user": {"id": 2}},
+                ]
+            }
+            comments = await adapter.get_comments("task_abc", limit=1)
+            assert len(comments) == 1
+            assert comments[0].content == "a"
+
+
+@pytest.mark.asyncio
+class TestHierarchyAndUsers:
+    """Epic helpers and user search."""
+
+    async def test_get_epic(self, adapter):
+        """get_epic reads a list and maps it to an Epic."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"id": "901000123", "name": "Sprint 1"}
+            epic = await adapter.get_epic("901000123")
+            assert epic.title == "Sprint 1"
+
+    async def test_list_subtasks(self, adapter):
+        """list_tasks_by_issue reads the parent then each subtask fully."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = [
+                {"id": "p1", "subtasks": [{"id": "s1"}, {"id": "s2"}]},
+                make_task_obj(id="s1", parent="p1"),
+                make_task_obj(id="s2", parent="p1"),
+            ]
+            subs = await adapter.list_tasks_by_issue("p1")
+            assert [t.id for t in subs] == ["s1", "s2"]
+            assert all(t.ticket_type == TicketType.TASK for t in subs)
+
+    async def test_search_users(self, adapter):
+        """search_users matches members by username/email."""
+        with patch.object(adapter.client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "teams": [
+                    {
+                        "id": "9007001",
+                        "members": [
+                            {
+                                "user": {
+                                    "id": 1,
+                                    "username": "jane",
+                                    "email": "jane@x.io",
+                                }
+                            },
+                            {"user": {"id": 2, "username": "bob", "email": "bob@x.io"}},
+                        ],
+                    }
+                ]
+            }
+            results = await adapter.search_users("jane")
+            assert len(results) == 1
+            assert results[0]["id"] == "1"
+            assert results[0]["email"] == "jane@x.io"
+
+
+# --------------------------------------------------------------------------
+# Milestones — unsupported
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestMilestonesUnsupported:
+    """Every milestone_* method raises NotImplementedError with a clear reason."""
+
+    async def test_milestone_create(self, adapter):
+        """milestone_create is unsupported."""
+        with pytest.raises(NotImplementedError, match="no native milestone"):
+            await adapter.milestone_create("M1")
+
+    async def test_milestone_get(self, adapter):
+        """milestone_get is unsupported."""
+        with pytest.raises(NotImplementedError, match="no native milestone"):
+            await adapter.milestone_get("m1")
+
+    async def test_milestone_list(self, adapter):
+        """milestone_list is unsupported."""
+        with pytest.raises(NotImplementedError, match="no native milestone"):
+            await adapter.milestone_list()
+
+    async def test_milestone_update(self, adapter):
+        """milestone_update is unsupported."""
+        with pytest.raises(NotImplementedError, match="no native milestone"):
+            await adapter.milestone_update("m1", name="x")
+
+    async def test_milestone_delete(self, adapter):
+        """milestone_delete is unsupported."""
+        with pytest.raises(NotImplementedError, match="no native milestone"):
+            await adapter.milestone_delete("m1")
+
+    async def test_milestone_get_issues(self, adapter):
+        """milestone_get_issues is unsupported."""
+        with pytest.raises(NotImplementedError, match="no native milestone"):
+            await adapter.milestone_get_issues("m1")
+
+
+# --------------------------------------------------------------------------
+# Client security: the auth token must never leak into errors/logs
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestClientSecurity:
+    """The personal token must not appear in raised exceptions."""
+
+    async def test_auth_header_set_without_bearer(self):
+        """ClickUp uses the raw token in Authorization (no 'Bearer ' prefix)."""
+        client = ClickUpClient("pk_secret_TOKEN")
+        assert client.headers["Authorization"] == "pk_secret_TOKEN"
+        assert "Bearer" not in client.headers["Authorization"]
+
+    async def test_error_message_excludes_token(self):
+        """A 4xx error message contains the status/detail but not the token."""
+        client = ClickUpClient("pk_secret_TOKEN")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                401, json={"err": "Token invalid", "ECODE": "OAUTH_017"}
+            )
+
+        transport = httpx.MockTransport(handler)
+        client._client = httpx.AsyncClient(transport=transport, headers=client.headers)
+
+        with pytest.raises(ValueError) as exc_info:
+            await client.get("/user")
+
+        message = str(exc_info.value)
+        assert "401" in message
+        assert "Token invalid" in message
+        assert "pk_secret_TOKEN" not in message
+        await client.close()
+
+    async def test_timeout_error_excludes_token(self):
+        """A timeout error message does not contain the token."""
+        client = ClickUpClient("pk_secret_TOKEN", max_retries=0)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.TimeoutException("timed out", request=request)
+
+        transport = httpx.MockTransport(handler)
+        client._client = httpx.AsyncClient(transport=transport, headers=client.headers)
+
+        with pytest.raises(ValueError) as exc_info:
+            await client.get("/user")
+
+        assert "pk_secret_TOKEN" not in str(exc_info.value)
+        await client.close()


### PR DESCRIPTION
Adds a complete **ClickUp** (REST API v2) backend adapter, modeled on the existing Asana REST adapter and registered as `clickup`.

## What's implemented
Full `BaseAdapter` contract:
- CRUD: `create` / `read` / `update` / `delete` / `list` / `search`
- `transition_state` — resolves ClickUp's **per-list statuses** ⇄ `TicketState` (via the list's `statuses[]` `type` + name)
- `add_comment` / `get_comments`, `search_users`
- Hierarchy: Epic→List, Issue→Task, Task→Subtask (list↔Epic helpers + `list_tasks_by_issue`)

Wiring: registered in `adapters/__init__.py`; env auto-discovery for `CLICKUP_API_TOKEN` / `CLICKUP_TEAM_ID` / `CLICKUP_LIST_ID` (+ optional `SPACE_ID`/`FOLDER_ID` and `MCP_TICKETER_CLICKUP_*` aliases); `.env.example` + README sections.

## Security
- Token travels **only** in the `Authorization` header — never logged, never in URLs/exceptions.
- Redirects disabled with explicit refusal (the base host is fixed `api.clickup.com`, so a 3xx could otherwise bounce the token to another host); error bodies not echoed; `Retry-After` bounded.

## Intentional `NotImplementedError` (documented in the docstring, `.env.example`, and README)
The six `milestone_*` methods. ClickUp has **no native milestone primitive** — Goals are a separate, semantically different concept (target/key-result aggregation, not label-grouped issues with a due date) — so milestones are explicitly unsupported in v1 rather than faked.

## Testing
- **74 unit tests** (mocked HTTP): CRUD, comments, priority/status mapping, hierarchy, registration, credential-not-in-error-messages, and the milestone-unsupported contract.
- `ruff` + `mypy` clean on the new package.

## ⚠️ Reviewers: mock-tested only
I do **not** have a ClickUp account/token, so this adapter has **not** been exercised against the live ClickUp API. The request shapes follow the documented ClickUp v2 API, but a maintainer with a ClickUp workspace should run a live smoke test (create/read/comment/transition/delete) before relying on it. Happy to iterate on any shape mismatches a live run surfaces.